### PR TITLE
SAN-220 Issuer Gateway Account Penalties API

### DIFF
--- a/handlers/penalties_test.go
+++ b/handlers/penalties_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/companieshouse/penalty-payment-api-core/models"
 	"github.com/companieshouse/penalty-payment-api/config"
-	"github.com/companieshouse/penalty-payment-api/service"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
 	"github.com/companieshouse/penalty-payment-api/utils"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -20,17 +20,17 @@ func TestUnitHandleGetPenalties(t *testing.T) {
 	allowedTransactionsMap := &models.AllowedTransactionMap{}
 
 	Convey("Given a request to get penalties", t, func() {
-		mockGetPenalties := func(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, service.ResponseType, error) {
+		mockedAccountPenalties := func(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, types.ResponseType, error) {
 			if companyNumber == "INVALID_COMPANY" {
-				return nil, service.Error, errors.New("error getting penalties")
+				return nil, types.Error, errors.New("error getting penalties")
 			}
 			if companyNumber == "INVALID_DATA" {
-				return nil, service.InvalidData, errors.New("error getting penalties")
+				return nil, types.InvalidData, errors.New("error getting penalties")
 			}
 			if companyNumber == "INTERNAL_SERVER_ERROR" {
-				return nil, service.NotFound, errors.New("error getting penalties")
+				return nil, types.NotFound, errors.New("error getting penalties")
 			}
-			return nil, service.Success, nil
+			return nil, types.Success, nil
 		}
 
 		mockedGetCompanyCode := func(penaltyReferenceType string) (string, error) {
@@ -38,7 +38,7 @@ func TestUnitHandleGetPenalties(t *testing.T) {
 		}
 
 		getCompanyCode = mockedGetCompanyCode
-		getPenalties = mockGetPenalties
+		accountPenalties = mockedAccountPenalties
 
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, config.CompanyNumber, "NI123546")

--- a/issuer_gateway/api/account_penalties.go
+++ b/issuer_gateway/api/account_penalties.go
@@ -1,1 +1,48 @@
 package api
+
+import (
+	"fmt"
+	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/penalty-payment-api-core/models"
+	"github.com/companieshouse/penalty-payment-api/config"
+	"github.com/companieshouse/penalty-payment-api/e5"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/private"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
+)
+
+var getTransactions = func(companyNumber string, companyCode string, client *e5.Client) (*e5.GetTransactionsResponse, error) {
+	return client.GetTransactions(&e5.GetTransactionsInput{CompanyNumber: companyNumber, CompanyCode: companyCode})
+}
+var getConfig = config.Get
+var generateTransactionList = private.GenerateTransactionListFromE5Response
+
+// AccountPenalties is a function that:
+// 1. makes a request to e5 to get a list of transactions for the specified company
+// 2. takes the results of this request and maps them to a format that the penalty-payment-web can consume
+func AccountPenalties(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap,
+	allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, types.ResponseType, error) {
+	cfg, err := getConfig()
+	if err != nil {
+		return nil, types.Error, nil
+	}
+	client := e5.NewClient(cfg.E5Username, cfg.E5APIURL)
+	e5Response, err := getTransactions(companyNumber, companyCode, client)
+
+	if err != nil {
+		log.Error(fmt.Errorf("error getting transaction list: [%v]", err))
+		return nil, types.Error, err
+	}
+
+	// Generate the CH preferred format of the results i.e. classify the transactions into payable "penalty" types or
+	// non-payable "other" types
+	generatedTransactionListFromE5Response, err :=
+		generateTransactionList(e5Response, companyCode, penaltyDetailsMap, allowedTransactionsMap)
+	if err != nil {
+		err = fmt.Errorf("error generating transaction list from the e5 response: [%v]", err)
+		log.Error(err)
+		return nil, types.Error, err
+	}
+
+	log.Info("Completed AccountPenalties request and mapped to CH penalty transactions", log.Data{"company_number": companyNumber})
+	return generatedTransactionListFromE5Response, types.Success, nil
+}

--- a/issuer_gateway/api/account_penalties_test.go
+++ b/issuer_gateway/api/account_penalties_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/companieshouse/penalty-payment-api-core/models"
+	"github.com/companieshouse/penalty-payment-api/config"
+	"github.com/companieshouse/penalty-payment-api/e5"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var companyNumber = "NI123456"
+var companyCode = "LP"
+var penaltyDetailsMap = &config.PenaltyDetailsMap{}
+var allowedTransactionMap = &models.AllowedTransactionMap{
+	Types: map[string]map[string]bool{
+		"1": {
+			"EJ": true,
+			"EU": true,
+		},
+	},
+}
+var transaction = e5.Transaction{
+	CompanyCode:     "LP",
+	TransactionType: "EU",
+}
+var page = e5.Page{
+	Size:          1,
+	TotalElements: 1,
+	TotalPages:    1,
+	Number:        1,
+}
+var e5TransactionsResponse = e5.GetTransactionsResponse{
+	Page: page,
+	Transactions: []e5.Transaction{
+		1: transaction,
+	},
+}
+
+func TestUnitAccountPenalties(t *testing.T) {
+	Convey("error when no transactions provided", t, func() {
+		_, responseType, err := AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionMap)
+		So(err, ShouldNotBeNil)
+		So(responseType, ShouldEqual, types.Error)
+	})
+
+	Convey("penalties returned when valid transactions", t, func() {
+		mockedGetTransactions := func(companyNumber string, companyCode string,
+			client *e5.Client) (*e5.GetTransactionsResponse, error) {
+			return &e5TransactionsResponse, nil
+		}
+
+		getTransactions = mockedGetTransactions
+
+		listResponse, responseType, err := AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionMap)
+		So(err, ShouldBeNil)
+		So(listResponse, ShouldNotBeNil)
+		So(responseType, ShouldEqual, types.Success)
+	})
+
+	Convey("error when transactions cannot be found", t, func() {
+		errGettingTransactions := errors.New("error getting transactions")
+		mockedGetTransactions := func(companyNumber string, companyCode string, client *e5.Client) (*e5.GetTransactionsResponse, error) {
+			return &e5.GetTransactionsResponse{}, errGettingTransactions
+		}
+
+		getTransactions = mockedGetTransactions
+
+		listResponse, responseType, err := AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionMap)
+		So(err, ShouldEqual, errGettingTransactions)
+		So(listResponse, ShouldBeNil)
+		So(responseType, ShouldEqual, types.Error)
+	})
+
+	Convey("error when generating transaction list fails", t, func() {
+		errGeneratingTransactionList := errors.New("error generating transaction list from the e5 response: [error generating etag]")
+		payableTransactionList := models.TransactionListResponse{}
+		mockedGetTransactions := func(companyNumber string, companyCode string,
+			client *e5.Client) (*e5.GetTransactionsResponse, error) {
+			return &e5TransactionsResponse, nil
+		}
+		mockedGenerateTransactionList := func(e5Response *e5.GetTransactionsResponse, companyCode string,
+			penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, error) {
+			return &payableTransactionList, errors.New("error generating etag")
+		}
+
+		getTransactions = mockedGetTransactions
+		generateTransactionList = mockedGenerateTransactionList
+
+		listResponse, responseType, err := AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionMap)
+		So(err, ShouldResemble, errGeneratingTransactionList)
+		So(listResponse, ShouldBeNil)
+		So(responseType, ShouldEqual, types.Error)
+	})
+
+	Convey("error when getConfig fails", t, func() {
+		errGettingConfig := errors.New("error getting config")
+		mockedGetConfig := func() (*config.Config, error) {
+			return nil, errGettingConfig
+		}
+
+		getConfig = mockedGetConfig
+
+		listResponse, responseType, err := AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionMap)
+		So(err, ShouldBeNil)
+		So(listResponse, ShouldBeNil)
+		So(responseType, ShouldEqual, types.Error)
+	})
+}

--- a/issuer_gateway/private/generate_transaction_list_from_e5_response.go
+++ b/issuer_gateway/private/generate_transaction_list_from_e5_response.go
@@ -1,1 +1,76 @@
 package private
+
+import (
+	"fmt"
+
+	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/penalty-payment-api-core/models"
+	"github.com/companieshouse/penalty-payment-api/config"
+	"github.com/companieshouse/penalty-payment-api/e5"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
+	"github.com/companieshouse/penalty-payment-api/utils"
+)
+
+var etagGenerator = utils.GenerateEtag
+
+func GenerateTransactionListFromE5Response(e5Response *e5.GetTransactionsResponse, companyCode string,
+	penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, error) {
+	payableTransactionList := models.TransactionListResponse{}
+	etag, err := etagGenerator()
+	if err != nil {
+		err = fmt.Errorf("error generating etag: [%v]", err)
+		log.Error(err)
+		return nil, err
+	}
+
+	payableTransactionList.Etag = etag
+	payableTransactionList.TotalResults = e5Response.Page.TotalElements
+
+	// Loop through e5 response and construct CH resources
+	for _, e5Transaction := range e5Response.Transactions {
+		transactionListItem, err := buildTransactionListItemFromE5Transaction(
+			&e5Transaction, allowedTransactionsMap, penaltyDetailsMap, companyCode)
+		if err != nil {
+			return nil, err
+		}
+
+		payableTransactionList.Items = append(payableTransactionList.Items, transactionListItem)
+	}
+
+	return &payableTransactionList, nil
+}
+
+func buildTransactionListItemFromE5Transaction(e5Transaction *e5.Transaction, allowedTransactionsMap *models.AllowedTransactionMap, penaltyDetailsMap *config.PenaltyDetailsMap, companyCode string) (models.TransactionListItem, error) {
+	etag, err := utils.GenerateEtag()
+	if err != nil {
+		err = fmt.Errorf("error generating etag: [%v]", err)
+		log.Error(err)
+		return models.TransactionListItem{}, err
+	}
+
+	transactionListItem := models.TransactionListItem{}
+	transactionListItem.Etag = etag
+	transactionListItem.ID = e5Transaction.TransactionReference
+	transactionListItem.IsPaid = e5Transaction.IsPaid
+	transactionListItem.Kind = penaltyDetailsMap.Details[companyCode].ResourceKind
+	transactionListItem.IsDCA = e5Transaction.AccountStatus == "DCA"
+	transactionListItem.DueDate = e5Transaction.DueDate
+	transactionListItem.MadeUpDate = e5Transaction.MadeUpDate
+	transactionListItem.TransactionDate = e5Transaction.TransactionDate
+	transactionListItem.OriginalAmount = e5Transaction.Amount
+	transactionListItem.Outstanding = e5Transaction.OutstandingAmount
+	transactionListItem.Type = getTransactionType(e5Transaction, allowedTransactionsMap)
+
+	return transactionListItem, nil
+}
+
+func getTransactionType(e5Transaction *e5.Transaction, allowedTransactionsMap *models.AllowedTransactionMap) string {
+	// Each transaction needs to be checked and identified as a 'penalty' or 'other'. This allows penalty-payment-web to determine
+	// which transactions are payable. This is done using a yaml file to map payable transactions
+	// Check if the transaction is allowed and set to 'penalty' if it is
+	if _, ok := allowedTransactionsMap.Types[e5Transaction.TransactionType][e5Transaction.TransactionSubType]; ok {
+		return types.Penalty.String()
+	} else {
+		return types.Other.String()
+	}
+}

--- a/issuer_gateway/private/generate_transaction_list_from_e5_response_test.go
+++ b/issuer_gateway/private/generate_transaction_list_from_e5_response_test.go
@@ -1,0 +1,87 @@
+package private
+
+import (
+	"errors"
+	"github.com/companieshouse/penalty-payment-api-core/models"
+	"github.com/companieshouse/penalty-payment-api/config"
+	"github.com/companieshouse/penalty-payment-api/e5"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var companyCode = "LP"
+var allowedTransactionMap = &models.AllowedTransactionMap{
+	Types: map[string]map[string]bool{
+		"1": {
+			"EJ": true,
+			"EU": true,
+		},
+	},
+}
+var euTransaction = e5.Transaction{
+	CompanyCode:        "LP",
+	TransactionType:    "1",
+	TransactionSubType: "EU",
+}
+var page = e5.Page{
+	Size:          1,
+	TotalElements: 1,
+	TotalPages:    1,
+	Number:        1,
+}
+var e5TransactionsResponseEu = e5.GetTransactionsResponse{
+	Page: page,
+	Transactions: []e5.Transaction{
+		euTransaction,
+	},
+}
+
+func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
+	Convey("error when etag generator fails", t, func() {
+		errorGeneratingEtag := errors.New("error generating etag")
+		etagGenerator = func() (string, error) {
+			return "", errorGeneratingEtag
+		}
+
+		transactionList, err := GenerateTransactionListFromE5Response(
+			&e5TransactionsResponseEu, companyCode, &config.PenaltyDetailsMap{}, allowedTransactionMap)
+		So(err, ShouldNotBeNil)
+		So(transactionList, ShouldBeNil)
+	})
+
+	Convey("transaction list successfully generated from E5 response - transaction type EU", t, func() {
+		etag := "ABCDE"
+		etagGenerator = func() (string, error) {
+			return etag, nil
+		}
+
+		transactionList, err := GenerateTransactionListFromE5Response(
+			&e5TransactionsResponseEu, companyCode, &config.PenaltyDetailsMap{}, allowedTransactionMap)
+		So(err, ShouldBeNil)
+		So(transactionList, ShouldNotBeNil)
+	})
+
+	Convey("transaction list successfully generated from E5 response - transaction type Other", t, func() {
+		etag := "ABCDE"
+		etagGenerator = func() (string, error) {
+			return etag, nil
+		}
+		otherTransaction := e5.Transaction{
+			CompanyCode:        "LP",
+			TransactionType:    "1",
+			TransactionSubType: "Other",
+		}
+		e5TransactionsResponseOther := e5.GetTransactionsResponse{
+			Page: page,
+			Transactions: []e5.Transaction{
+				otherTransaction,
+			},
+		}
+
+		transactionList, err := GenerateTransactionListFromE5Response(
+			&e5TransactionsResponseOther, companyCode, &config.PenaltyDetailsMap{}, allowedTransactionMap)
+		So(err, ShouldBeNil)
+		So(transactionList, ShouldNotBeNil)
+	})
+}

--- a/issuer_gateway/types/response_type.go
+++ b/issuer_gateway/types/response_type.go
@@ -1,0 +1,34 @@
+package types
+
+// ResponseType enumerates the types of authentication supported
+type ResponseType int
+
+const (
+	// InvalidData response
+	InvalidData ResponseType = iota
+
+	// Error response
+	Error
+
+	// Forbidden response
+	Forbidden
+
+	// NotFound response
+	NotFound
+
+	// Success response
+	Success
+)
+
+var vals = [...]string{
+	"invalid-data",
+	"error",
+	"forbidden",
+	"not-found",
+	"success",
+}
+
+// String representation of `ResponseType`
+func (a ResponseType) String() string {
+	return vals[a]
+}

--- a/issuer_gateway/types/response_type_test.go
+++ b/issuer_gateway/types/response_type_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitResponseType(t *testing.T) {
+	Convey("Given the defined ResponseTypes", t, func() {
+		testCases := []struct {
+			input    ResponseType
+			expected string
+		}{
+			{input: InvalidData, expected: "invalid-data"},
+			{input: Error, expected: "error"},
+			{input: Forbidden, expected: "forbidden"},
+			{input: NotFound, expected: "not-found"},
+			{input: Success, expected: "success"},
+		}
+		Convey("When String is called", func() {
+			for _, testCase := range testCases {
+				testCase := testCase
+
+				Convey("Then the correct string should be returned for "+testCase.expected, func() {
+					result := testCase.input.String()
+					So(result, ShouldEqual, testCase.expected)
+				})
+			}
+		})
+	})
+}

--- a/issuer_gateway/types/transaction_type.go
+++ b/issuer_gateway/types/transaction_type.go
@@ -1,1 +1,20 @@
 package types
+
+// TransactionType Enum Type
+type TransactionType int
+
+// Enumeration containing all possible types when mapping e5 transactions
+const (
+	Penalty TransactionType = 1 + iota
+	Other
+)
+
+// String representation of transaction types
+var transactionTypes = [...]string{
+	"penalty",
+	"other",
+}
+
+func (transactionType TransactionType) String() string {
+	return transactionTypes[transactionType-1]
+}

--- a/issuer_gateway/types/transaction_type_test.go
+++ b/issuer_gateway/types/transaction_type_test.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitTransactionType(t *testing.T) {
+	Convey("Given the defined TransactionTypes", t, func() {
+		testCases := []struct {
+			input    TransactionType
+			expected string
+		}{
+			{input: Penalty, expected: "penalty"},
+			{input: Other, expected: "other"},
+		}
+		Convey("When String is called", func() {
+			for _, testCase := range testCases {
+				testCase := testCase
+
+				Convey("Then the correct string should be returned for "+testCase.expected, func() {
+					result := testCase.input.String()
+					So(result, ShouldEqual, testCase.expected)
+				})
+			}
+		})
+	})
+}


### PR DESCRIPTION
* Copied the function service.penalties.GetPenalties to issuer_gateway.api.AccountPenalties and refactored the copied function.
* Copied the private function service.penalties.generateTransactionListFromE5Response to issuer_gateway.private.GenerateTransactionListFromE5Response and refactored the copied function.
* Refactored and moved some relevant types to issuer_gateway.types.
* Refactored handlers.penalties.HandleGetPenalties to call the new issuer_gateway AccountPenalties.
* Updated existing unit tests and created new unit tests for acceptable coverage.