### PR TITLE
SAN-229 Update Healthcheck endpoints to include penalty-payment-api in base path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/golang:1.19-bullseye-builder AS BUILDER
+FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/golang:1.19-bullseye-builder AS builder
 
 RUN /bin/go_build
 
 FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/golang:debian11-runtime
 
-COPY --from=BUILDER /build/out/app ./
+COPY --from=builder /build/out/app ./
 
 COPY assets ./assets
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ In order to run this API locally you will need to install the following:
 ## Endpoints
 | Method    | Path                                                                   | Description                                                           |
 |:----------|:-----------------------------------------------------------------------|:----------------------------------------------------------------------|
-| **GET**   | `/healthcheck`                                                         | Standard healthcheck endpoint                                         |
-| **GET**   | `/healthcheck/finance-system`                                          | Healthcheck endpoint to check whether the finance system is available |
+| **GET**   | `/penalty-payment-api/healthcheck`                                     | Standard healthcheck endpoint                                         |
+| **GET**   | `/penalty-payment-api/healthcheck/finance-system`                      | Healthcheck endpoint to check whether the finance system is available |
 | **GET**   | `/company/{company_number}/penalties/late-filing`                      | List the Late Filing Penalties for a company                          |
 | **POST**  | `/company/{company_number}/penalties/late-filing/payable`              | Create a payable penalty resource                                     |
 | **GET**   | `/company/{company_number}/penalties/late-filing/payable/{id}`         | Get a payable resource                                                |

--- a/handlers/healthcheck_finance_test.go
+++ b/handlers/healthcheck_finance_test.go
@@ -23,7 +23,7 @@ func TestUnitHandleHealthCheckFinance(t *testing.T) {
 			cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", now.Hour()-100)
 			cfg.WeeklyMaintenanceDay = now.Weekday()
 
-			req, _ := http.NewRequest("GET", "/healthcheck/finance-system", nil)
+			req, _ := http.NewRequest("GET", "/penalty-payment-api/healthcheck/finance-system", nil)
 			w := httptest.NewRecorder()
 			HandleHealthCheckFinanceSystem(w, req)
 
@@ -43,7 +43,7 @@ func TestUnitHandleHealthCheckFinance(t *testing.T) {
 			cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", now.Hour()+100)
 			cfg.WeeklyMaintenanceDay = now.Weekday()
 
-			req, _ := http.NewRequest("GET", "/healthcheck/finance-system", nil)
+			req, _ := http.NewRequest("GET", "/penalty-payment-api/healthcheck/finance-system", nil)
 			w := httptest.NewRecorder()
 			HandleHealthCheckFinanceSystem(w, req)
 
@@ -65,7 +65,7 @@ func TestUnitHandleHealthCheckFinance(t *testing.T) {
 			cfg.PlannedMaintenanceStart = (now.AddDate(0, 0, -1)).Format("02 Jan 06 15:04 MST")
 			cfg.PlannedMaintenanceEnd = (now.AddDate(0, 0, 1)).Format("02 Jan 06 15:04 MST")
 
-			req, _ := http.NewRequest("GET", "/healthcheck/finance-system", nil)
+			req, _ := http.NewRequest("GET", "/penalty-payment-api/healthcheck/finance-system", nil)
 			w := httptest.NewRecorder()
 			HandleHealthCheckFinanceSystem(w, req)
 
@@ -86,7 +86,7 @@ func TestUnitHandleHealthCheckFinance(t *testing.T) {
 			cfg.WeeklyMaintenanceDay = now.Weekday()
 			cfg.PlannedMaintenanceStart = "invalid"
 
-			req, _ := http.NewRequest("GET", "/healthcheck/finance-system", nil)
+			req, _ := http.NewRequest("GET", "/penalty-payment-api/healthcheck/finance-system", nil)
 			w := httptest.NewRecorder()
 			HandleHealthCheckFinanceSystem(w, req)
 
@@ -103,7 +103,7 @@ func TestUnitHandleHealthCheckFinance(t *testing.T) {
 			cfg.PlannedMaintenanceStart = (now).Format("02 Jan 06 15:04 MST")
 			cfg.PlannedMaintenanceEnd = "invalid"
 
-			req, _ := http.NewRequest("GET", "/healthcheck/finance-system", nil)
+			req, _ := http.NewRequest("GET", "/penalty-payment-api/healthcheck/finance-system", nil)
 			w := httptest.NewRecorder()
 			HandleHealthCheckFinanceSystem(w, req)
 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -49,8 +49,8 @@ func Register(mainRouter *mux.Router, cfg *config.Config, svc dao.Service, penal
 		RequireElevatedAPIKeyPrivilege: true,
 	}
 
-	mainRouter.HandleFunc("/healthcheck", healthCheck).Methods(http.MethodGet).Name("healthcheck")
-	mainRouter.HandleFunc("/healthcheck/finance-system", HandleHealthCheckFinanceSystem).Methods(http.MethodGet).Name("healthcheck-finance-system")
+	mainRouter.HandleFunc("/penalty-payment-api/healthcheck", healthCheck).Methods(http.MethodGet).Name("healthcheck")
+	mainRouter.HandleFunc("/penalty-payment-api/healthcheck/finance-system", HandleHealthCheckFinanceSystem).Methods(http.MethodGet).Name("healthcheck-finance-system")
 
 	appRouter := mainRouter.PathPrefix("/company/{company_number}/penalties/late-filing").Subrouter()
 	appRouter.HandleFunc("", HandleGetPenalties(penaltyDetailsMap, allowedTransactionsMap)).Methods(http.MethodGet).Name("get-penalties-original")

--- a/issuer_gateway/api/healthcheck_finance_test.go
+++ b/issuer_gateway/api/healthcheck_finance_test.go
@@ -29,8 +29,8 @@ func TestUnitCheckScheduledMaintenance(t *testing.T) {
 		// Given
 		startHour := currentTime.Hour() - 2
 		endHour := startHour + 1
-		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%d00", startHour)
-		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%d00", endHour)
+		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%02d00", startHour)
+		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", endHour)
 		cfg.WeeklyMaintenanceDay = currentTime.Weekday()
 
 		// When
@@ -45,8 +45,8 @@ func TestUnitCheckScheduledMaintenance(t *testing.T) {
 	Convey("Current time is during weekly maintenance times", t, func() {
 		// Given
 		endHour := currentTime.Hour() + 1
-		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%d00", currentTime.Hour())
-		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%d00", endHour)
+		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%02d00", currentTime.Hour())
+		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", endHour)
 		cfg.WeeklyMaintenanceDay = currentTime.Weekday()
 
 		// When
@@ -62,8 +62,8 @@ func TestUnitCheckScheduledMaintenance(t *testing.T) {
 		// Given
 		startHour := currentTime.Hour() + 1
 		endHour := currentTime.Hour() + 2
-		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%d00", startHour)
-		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%d00", endHour)
+		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%02d00", startHour)
+		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", endHour)
 		cfg.WeeklyMaintenanceDay = currentTime.Weekday()
 
 		// When
@@ -154,8 +154,8 @@ func TestUnitCheckScheduledMaintenance(t *testing.T) {
 	Convey("Current time is during scheduled maintenance times, planned ends later", t, func() {
 		// Given
 		weeklyEndHour := currentTime.Hour() + 1
-		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%d00", currentTime.Hour())
-		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%d00", weeklyEndHour)
+		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%02d00", currentTime.Hour())
+		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", weeklyEndHour)
 		cfg.WeeklyMaintenanceDay = currentTime.Weekday()
 		plannedStartTime := currentTime.Add(time.Minute * -1).Truncate(time.Minute).Round(0)
 		cfg.PlannedMaintenanceStart = plannedStartTime.Format(time.RFC822)
@@ -174,8 +174,8 @@ func TestUnitCheckScheduledMaintenance(t *testing.T) {
 	Convey("Current time is during scheduled maintenance times, planned ends earlier", t, func() {
 		// Given
 		weeklyEndHour := currentTime.Hour() + 2
-		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%d00", currentTime.Hour())
-		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%d00", weeklyEndHour)
+		cfg.WeeklyMaintenanceStartTime = fmt.Sprintf("%02d00", currentTime.Hour())
+		cfg.WeeklyMaintenanceEndTime = fmt.Sprintf("%02d00", weeklyEndHour)
 		cfg.WeeklyMaintenanceDay = currentTime.Weekday()
 		plannedStartTime := currentTime.Add(time.Hour * -1).Truncate(time.Minute).Round(0)
 		cfg.PlannedMaintenanceStart = plannedStartTime.Format(time.RFC822)

--- a/routes.yaml
+++ b/routes.yaml
@@ -7,4 +7,4 @@ weight: 900
 routes:
   1: ^/company/(.*)/penalties/late-filing
   2: ^/company/(.*)/penalties/late-filing.*
-  3: ^/healthcheck/finance-system
+  3: ^/penalty-payment-api/healthcheck/finance-system

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -21,7 +21,7 @@
     }
   ],
   "paths": {
-    "/healthcheck": {
+    "/penalty-payment-api/healthcheck": {
       "get": {
         "tags": [
           "Healthcheck"
@@ -29,12 +29,12 @@
         "description": "Check the health of the Penalty Payment Service (PPS) API",
         "responses": {
           "200": {
-            "description": "healthy"
+            "description": "Healthy"
           }
         }
       }
     },
-    "/healthcheck/finance-system": {
+    "/penalty-payment-api/healthcheck/finance-system": {
       "get": {
         "tags": [
           "Healthcheck"
@@ -42,10 +42,10 @@
         "description": "Check the health of the Finance System",
         "responses": {
           "200": {
-            "description": "healthy"
+            "description": "Healthy"
           },
           "503": {
-            "description": "service unavailable",
+            "description": "Service unavailable",
             "schema": {
               "$ref": "#/definitions/ServiceUnavailable"
             }


### PR DESCRIPTION
[SAN-229](https://companieshouse.atlassian.net/browse/SAN-229) Update Healthcheck endpoints to include penalty-payment-api in base path
* GET /penalty-payment-api/healthcheck
* GET /penalty-payment-api/healthcheck/finance-system

[SAN-229]: https://companieshouse.atlassian.net/browse/SAN-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ