### PR TITLE
SAN-230 Remove EmailFilingDesc config and use new transactionListItem.Reason field in API (via IG api.AccountPenalties)

### DIFF
--- a/assets/penalty_details.yml
+++ b/assets/penalty_details.yml
@@ -7,7 +7,6 @@ details:
     ResourceKind: "late-filing-penalty#late-filing-penalty"
     ProductType: "late-filing-penalty"
     EmailReceivedAppId: "penalty-payment-api.penalty_payment_received_email"
-    EmailFilingDesc: "Late filing of accounts"
     EmailMsgType: "penalty_payment_received_email"
   C1:
     Description: "Sanctions Penalty Payment"
@@ -15,5 +14,4 @@ details:
     ResourceKind: "penalty#sanctions"
     ProductType: "penalty-sanctions"
     EmailReceivedAppId: "penalty-payment-api.penalty_payment_received_email"
-    EmailFilingDesc: "Failure to file a confirmation statement"
     EmailMsgType: "penalty_payment_received_email"

--- a/config/config.go
+++ b/config/config.go
@@ -2,13 +2,13 @@
 package config
 
 import (
-	"github.com/companieshouse/penalty-payment-api-core/models"
-	"gopkg.in/yaml.v2"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/companieshouse/gofigure"
+	"github.com/companieshouse/penalty-payment-api-core/models"
+	"gopkg.in/yaml.v2"
 )
 
 var cfg *Config
@@ -45,7 +45,6 @@ type PenaltyDetails struct {
 	ResourceKind       string `yaml:"ResourceKind"`
 	ProductType        string `yaml:"ProductType"`
 	EmailReceivedAppId string `yaml:"EmailReceivedAppId"`
-	EmailFilingDesc    string `yaml:"EmailFilingDesc"`
 	EmailMsgType       string `yaml:"EmailMsgType"`
 }
 

--- a/service/email_service.go
+++ b/service/email_service.go
@@ -129,7 +129,7 @@ func prepareKafkaMessage(emailSendSchema avro.Schema, payableResource models.Pay
 		TransactionDate:   time.Now().Format("2 January 2006"),
 		Amount:            fmt.Sprintf("%g", payedTransaction.OriginalAmount),
 		CompanyName:       companyName,
-		FilingDescription: penaltyDetailsMap.Details[companyCode].EmailFilingDesc,
+		FilingDescription: payedTransaction.Reason,
 		To:                payableResource.CreatedBy.Email,
 		Subject:           fmt.Sprintf("Confirmation of your Companies House penalty payment"),
 		CHSURL:            cfg.CHSURL,

--- a/service/email_service_test.go
+++ b/service/email_service_test.go
@@ -192,7 +192,7 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			mockedGetTransactionForPenalty := func(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
 				allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
 
-				return &models.TransactionListItem{ID: "A1234567"}, nil
+				return &models.TransactionListItem{ID: "A1234567", Reason: "Late filing of accounts"}, nil
 			}
 
 			getConfig = mockedConfigGet
@@ -215,7 +215,7 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			mockedGetTransactionForPenalty := func(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
 				allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
 
-				return &models.TransactionListItem{ID: "A123567", MadeUpDate: "2006-01-02", TransactionDate: "2006-01-02"}, nil
+				return &models.TransactionListItem{ID: "A123567", MadeUpDate: "2006-01-02", TransactionDate: "2006-01-02", Reason: "Late filing of accounts"}, nil
 			}
 
 			getConfig = mockedConfigGet

--- a/service/penalties.go
+++ b/service/penalties.go
@@ -11,6 +11,7 @@ import (
 	"github.com/companieshouse/penalty-payment-api/config"
 	"github.com/companieshouse/penalty-payment-api/e5"
 	"github.com/companieshouse/penalty-payment-api/issuer_gateway/api"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
 	"github.com/companieshouse/penalty-payment-api/utils"
 )
 
@@ -35,6 +36,11 @@ func (transactionType TransactionType) String() string {
 
 var getTransactions = func(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap, client *e5.Client) (*e5.GetTransactionsResponse, error) {
 	return client.GetTransactions(&e5.GetTransactionsInput{CompanyNumber: companyNumber, CompanyCode: companyCode})
+}
+
+var getAccountPenalties = func(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap,
+	allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, types.ResponseType, error) {
+	return api.AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
 }
 
 // GetPenalties is a function that:
@@ -71,7 +77,7 @@ func GetPenalties(companyNumber string, companyCode string, penaltyDetailsMap *c
 // GetTransactionForPenalty returns a single, specified, transaction from e5 for a specific company
 func GetTransactionForPenalty(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
 	allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
-	response, _, err := api.AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
+	response, _, err := getAccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/service/penalties.go
+++ b/service/penalties.go
@@ -10,6 +10,7 @@ import (
 	"github.com/companieshouse/penalty-payment-api-core/validators"
 	"github.com/companieshouse/penalty-payment-api/config"
 	"github.com/companieshouse/penalty-payment-api/e5"
+	"github.com/companieshouse/penalty-payment-api/issuer_gateway/api"
 	"github.com/companieshouse/penalty-payment-api/utils"
 )
 
@@ -70,7 +71,7 @@ func GetPenalties(companyNumber string, companyCode string, penaltyDetailsMap *c
 // GetTransactionForPenalty returns a single, specified, transaction from e5 for a specific company
 func GetTransactionForPenalty(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
 	allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
-	response, _, err := GetPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
+	response, _, err := api.AccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
 	if err != nil {
 		log.Error(err)
 		return nil, err


### PR DESCRIPTION
[SAN-230](https://companieshouse.atlassian.net/browse/SAN-230) Remove `EmailFilingDesc` config and use new `transactionListItem.Reason` field in API (via IG `api.AccountPenalties`)

[SAN-230]: https://companieshouse.atlassian.net/browse/SAN-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ