### PR TITLE
SAN-224 Use Issuer Gateway PayablePenalty API in Send Email service

### DIFF
--- a/handlers/create_payable_resource_test.go
+++ b/handlers/create_payable_resource_test.go
@@ -235,7 +235,10 @@ func TestUnitCreatePayableResourceHandler(t *testing.T) {
 
 		httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(200, e5ResponseLateFiling))
 
-		body, _ := json.Marshal(&models.PayableRequest{})
+		body, _ := json.Marshal(&models.PayableRequest{
+			CompanyNumber: "10000024",
+			CreatedBy:     authentication.AuthUserDetails{},
+		})
 		res := serveCreatePayableResourceHandler(body, mocks.NewMockService(mockCtrl), true)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)

--- a/issuer_gateway/api/account_penalties.go
+++ b/issuer_gateway/api/account_penalties.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/penalty-payment-api-core/models"
 	"github.com/companieshouse/penalty-payment-api/config"

--- a/issuer_gateway/api/payable_penalty.go
+++ b/issuer_gateway/api/payable_penalty.go
@@ -11,8 +11,8 @@ import (
 var getAccountPenalties = AccountPenalties
 var getMatchingPenalty = private.MatchPenalty
 
-func PayablePenalty(companyNumber string, companyCode string, txs []models.TransactionItem,
-	penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) ([]models.TransactionItem, error) {
+func PayablePenalty(companyNumber string, companyCode string, transaction models.TransactionItem,
+	penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionItem, error) {
 
 	response, _, err := getAccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
 	if err != nil {
@@ -27,10 +27,10 @@ func PayablePenalty(companyNumber string, companyCode string, txs []models.Trans
 			"company_number": companyNumber,
 			"penalty_count":  unpaidPenaltyCount,
 		})
-		return []models.TransactionItem{}, private.ErrMultiplePenalties
+		return nil, private.ErrMultiplePenalties
 	}
 
-	return getMatchingPenalty(response.Items, txs, companyNumber)
+	return getMatchingPenalty(response.Items, transaction, companyNumber)
 }
 
 func getUnpaidPenaltyCount(transactionListItems []models.TransactionListItem) int {

--- a/issuer_gateway/api/payable_penalty_test.go
+++ b/issuer_gateway/api/payable_penalty_test.go
@@ -58,9 +58,7 @@ func TestUnitPayablePenalty(t *testing.T) {
 			},
 		},
 	}
-	txs := []models.TransactionItem{
-		{TransactionID: "121"},
-	}
+	transaction := models.TransactionItem{TransactionID: "121"}
 
 	Convey("error is returned when fetching account penalties fails", t, func() {
 		accountPenaltiesErr := errors.New("failed to fetch account penalties")
@@ -70,7 +68,7 @@ func TestUnitPayablePenalty(t *testing.T) {
 		}
 		getAccountPenalties = mockedAccountPenalties
 
-		payablePenalty, err := PayablePenalty("10000024", "LP", txs, penaltyDetailsMap, allowedTransactionMap)
+		payablePenalty, err := PayablePenalty("10000024", "LP", transaction, penaltyDetailsMap, allowedTransactionMap)
 
 		So(payablePenalty, ShouldBeNil)
 		So(err, ShouldEqual, accountPenaltiesErr)
@@ -83,7 +81,7 @@ func TestUnitPayablePenalty(t *testing.T) {
 		}
 		getAccountPenalties = mockedAccountPenalties
 
-		_, err := PayablePenalty("10000024", "LP", txs, penaltyDetailsMap, allowedTransactionMap)
+		_, err := PayablePenalty("10000024", "LP", transaction, penaltyDetailsMap, allowedTransactionMap)
 
 		So(err, ShouldBeError, private.ErrMultiplePenalties)
 	})
@@ -93,22 +91,21 @@ func TestUnitPayablePenalty(t *testing.T) {
 			allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, types.ResponseType, error) {
 			return accountPenaltiesResponse(1), types.Success, nil
 		}
-		wantPayablePenalty := []models.TransactionItem{
-			{TransactionID: "121",
-				Amount:     150,
-				Type:       "penalty",
-				MadeUpDate: "2017-06-30",
-				IsDCA:      false,
-				IsPaid:     false,
-			},
+		wantPayablePenalty := &models.TransactionItem{
+			TransactionID: "121",
+			Amount:        150,
+			Type:          "penalty",
+			MadeUpDate:    "2017-06-30",
+			IsDCA:         false,
+			IsPaid:        false,
 		}
-		mockedMatchPenalty := func(referenceTransactions []models.TransactionListItem, transactionsToMatch []models.TransactionItem, companyNumber string) ([]models.TransactionItem, error) {
+		mockedMatchPenalty := func(referenceTransactions []models.TransactionListItem, transactionToMatch models.TransactionItem, companyNumber string) (*models.TransactionItem, error) {
 			return wantPayablePenalty, nil
 		}
 		getAccountPenalties = mockedAccountPenalties
 		getMatchingPenalty = mockedMatchPenalty
 
-		gotPayablePenalty, err := PayablePenalty("10000024", "LP", txs, penaltyDetailsMap, allowedTransactionMap)
+		gotPayablePenalty, err := PayablePenalty("10000024", "LP", transaction, penaltyDetailsMap, allowedTransactionMap)
 
 		So(gotPayablePenalty, ShouldResemble, wantPayablePenalty)
 		So(err, ShouldBeNil)

--- a/issuer_gateway/private/match_penalty.go
+++ b/issuer_gateway/private/match_penalty.go
@@ -20,42 +20,36 @@ var (
 )
 
 func MatchPenalty(referenceTransactions []models.TransactionListItem,
-	transactionsToMatch []models.TransactionItem,
-	companyNumber string) ([]models.TransactionItem, error) {
+	transactionToMatch models.TransactionItem,
+	companyNumber string) (*models.TransactionItem, error) {
 
 	referenceTransactionsMap := mapTransactions(referenceTransactions)
-	var matchedPenalties []models.TransactionItem
-
-	for _, t := range transactionsToMatch {
-		data := map[string]interface{}{
-			"transaction_ref": t.TransactionID,
-			"company_number":  companyNumber,
-		}
-
-		transaction, ok := referenceTransactionsMap[t.TransactionID]
-		if !ok {
-			log.Info("disallowing paying for a transaction that does not exist in E5", data)
-			return nil, ErrTransactionDoesNotExist
-		}
-
-		valid, err := validate(transaction, data, t)
-		if valid {
-			matchedPenalty := models.TransactionItem{
-				TransactionID: t.TransactionID,
-				Amount:        t.Amount,
-				Type:          transaction.Type,
-				MadeUpDate:    transaction.MadeUpDate,
-				IsDCA:         transaction.IsDCA,
-				IsPaid:        transaction.IsPaid,
-				Reason:        transaction.Reason,
-			}
-			matchedPenalties = append(matchedPenalties, matchedPenalty)
-		} else {
-			return nil, err[0]
-		}
+	transactionInfo := map[string]interface{}{
+		"transaction_ref": transactionToMatch.TransactionID,
+		"company_number":  companyNumber,
 	}
 
-	return matchedPenalties, nil
+	matched, ok := referenceTransactionsMap[transactionToMatch.TransactionID]
+	if !ok {
+		log.Info("disallowing paying for a transaction that does not exist in E5", transactionInfo)
+		return nil, ErrTransactionDoesNotExist
+	}
+
+	valid, err := validate(matched, transactionInfo, transactionToMatch)
+	if valid {
+		matchedPenalty := models.TransactionItem{
+			TransactionID: matched.ID,
+			Amount:        matched.Outstanding,
+			Type:          matched.Type,
+			MadeUpDate:    matched.MadeUpDate,
+			IsDCA:         matched.IsDCA,
+			IsPaid:        matched.IsPaid,
+			Reason:        matched.Reason,
+		}
+		return &matchedPenalty, nil
+	} else {
+		return nil, err[0]
+	}
 }
 
 func validate(

--- a/issuer_gateway/private/match_penalty_test.go
+++ b/issuer_gateway/private/match_penalty_test.go
@@ -10,24 +10,20 @@ import (
 func TestUnitMatchPenalty(t *testing.T) {
 
 	companyNumber := "123"
-	transactionsToMatch := []models.TransactionItem{
-		{
-			TransactionID: "121",
-			Type:          "penalty",
-			Amount:        150,
-			Reason:        "Failure to file a confirmation statement",
-		},
+	transactionsToMatch := models.TransactionItem{
+		TransactionID: "121",
+		Type:          "penalty",
+		Amount:        150,
+		Reason:        "Failure to file a confirmation statement",
 	}
-	matchedPenalties := []models.TransactionItem{
-		{
-			TransactionID: "121",
-			Amount:        150,
-			Type:          "penalty",
-			MadeUpDate:    "2017-06-30",
-			Reason:        "Failure to file a confirmation statement",
-			IsDCA:         false,
-			IsPaid:        false,
-		},
+	matchedPenalty := models.TransactionItem{
+		TransactionID: "121",
+		Amount:        150,
+		Type:          "penalty",
+		MadeUpDate:    "2017-06-30",
+		Reason:        "Failure to file a confirmation statement",
+		IsDCA:         false,
+		IsPaid:        false,
 	}
 
 	testCases := []struct {
@@ -39,7 +35,7 @@ func TestUnitMatchPenalty(t *testing.T) {
 		IsPaid         bool
 		OriginalAmount float64
 		Outstanding    float64
-		WantMatched    []models.TransactionItem
+		WantMatched    *models.TransactionItem
 		WantError      error
 	}{
 		{TransactionID: "120", Outstanding: 150, Type: "penalty", MadeUpDate: "2017-06-30", Reason: "Failure to file a confirmation statement",
@@ -55,7 +51,7 @@ func TestUnitMatchPenalty(t *testing.T) {
 		{TransactionID: "121", Outstanding: 150, Type: "penalty", MadeUpDate: "2017-06-30", Reason: "Failure to file a confirmation statement",
 			OriginalAmount: 150, IsDCA: true, IsPaid: false, WantMatched: nil, WantError: ErrTransactionDCA},
 		{TransactionID: "121", Outstanding: 150, Type: "penalty", MadeUpDate: "2017-06-30", Reason: "Failure to file a confirmation statement",
-			OriginalAmount: 150, IsDCA: false, IsPaid: false, WantMatched: matchedPenalties, WantError: nil},
+			OriginalAmount: 150, IsDCA: false, IsPaid: false, WantMatched: &matchedPenalty, WantError: nil},
 	}
 
 	Convey("matchPenalty works correctly for different scenarios", t, func() {

--- a/service/email_service_test.go
+++ b/service/email_service_test.go
@@ -192,13 +192,10 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			mockedGetCompanyName := func(companyNumber string, req *http.Request) (string, error) {
 				return "Brewery", nil
 			}
-			mockedGetPayablePenalty := func(companyNumber string,
-				companyCode string,
-				txs []models.TransactionItem,
-				penaltyDetailsMap *config.PenaltyDetailsMap,
-				allowedTransactionsMap *models.AllowedTransactionMap) ([]models.TransactionItem, error) {
+			mockedGetPayablePenalty := func(companyNumber string, companyCode string, t models.TransactionItem,
+				penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionItem, error) {
 
-				return []models.TransactionItem{{TransactionID: "A1234567", Reason: "Late filing of accounts"}}, nil
+				return &models.TransactionItem{TransactionID: "A1234567", Reason: "Late filing of accounts"}, nil
 			}
 
 			getConfig = mockedConfigGet
@@ -219,14 +216,13 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			mockedGetCompanyName := func(companyNumber string, req *http.Request) (string, error) {
 				return "Brewery", nil
 			}
-			mockedGetPayablePenalty := func(companyNumber string,
-				companyCode string,
-				txs []models.TransactionItem,
-				penaltyDetailsMap *config.PenaltyDetailsMap,
-				allowedTransactionsMap *models.AllowedTransactionMap) ([]models.TransactionItem, error) {
+			mockedGetPayablePenalty := func(companyNumber string, companyCode string, t models.TransactionItem,
+				penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionItem, error) {
 
-				return []models.TransactionItem{
-					{TransactionID: "A123567", MadeUpDate: "2006-01-02", Reason: "Late filing of accounts"}}, nil
+				return &models.TransactionItem{
+					TransactionID: "A123567",
+					MadeUpDate:    "2006-01-02",
+					Reason:        "Late filing of accounts"}, nil
 			}
 
 			getConfig = mockedConfigGet

--- a/service/email_service_test.go
+++ b/service/email_service_test.go
@@ -143,7 +143,8 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 					getConfig = mockedConfigGet
 
 					Convey("Then an error should be returned", func() {
-						_, err := prepareKafkaMessage(producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
+						_, err := prepareKafkaMessage(
+							producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
 
 						So(err, ShouldResemble, errors.New("error getting config: ["+errMsg+"]"))
 					})
@@ -160,7 +161,8 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			getConfig = mockedConfigGet
 
 			Convey("Then an error should be returned", func() {
-				_, err := prepareKafkaMessage(producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
+				_, err := prepareKafkaMessage(
+					producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
 
 				So(err.Error(), ShouldStartWith, "error getting company name: [")
 			})
@@ -177,7 +179,8 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			getCompanyName = mockedGetCompanyName
 
 			Convey("Then an error should be returned", func() {
-				_, err := prepareKafkaMessage(producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
+				_, err := prepareKafkaMessage(
+					producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
 
 				So(err.Error(), ShouldStartWith, "error getting transaction for penalty: [")
 			})
@@ -189,18 +192,22 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			mockedGetCompanyName := func(companyNumber string, req *http.Request) (string, error) {
 				return "Brewery", nil
 			}
-			mockedGetTransactionForPenalty := func(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
-				allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
+			mockedGetPayablePenalty := func(companyNumber string,
+				companyCode string,
+				txs []models.TransactionItem,
+				penaltyDetailsMap *config.PenaltyDetailsMap,
+				allowedTransactionsMap *models.AllowedTransactionMap) ([]models.TransactionItem, error) {
 
-				return &models.TransactionListItem{ID: "A1234567", Reason: "Late filing of accounts"}, nil
+				return []models.TransactionItem{{TransactionID: "A1234567", Reason: "Late filing of accounts"}}, nil
 			}
 
 			getConfig = mockedConfigGet
 			getCompanyName = mockedGetCompanyName
-			getTransactionForPenalty = mockedGetTransactionForPenalty
+			getPayablePenalty = mockedGetPayablePenalty
 
 			Convey("Then an error should be returned", func() {
-				_, err := prepareKafkaMessage(producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
+				_, err := prepareKafkaMessage(
+					producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)
 
 				So(err, ShouldResemble, errors.New("error parsing made up date: [parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\"]"))
 			})
@@ -212,15 +219,19 @@ func TestUnitPrepareKafkaMessage(t *testing.T) {
 			mockedGetCompanyName := func(companyNumber string, req *http.Request) (string, error) {
 				return "Brewery", nil
 			}
-			mockedGetTransactionForPenalty := func(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
-				allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
+			mockedGetPayablePenalty := func(companyNumber string,
+				companyCode string,
+				txs []models.TransactionItem,
+				penaltyDetailsMap *config.PenaltyDetailsMap,
+				allowedTransactionsMap *models.AllowedTransactionMap) ([]models.TransactionItem, error) {
 
-				return &models.TransactionListItem{ID: "A123567", MadeUpDate: "2006-01-02", TransactionDate: "2006-01-02", Reason: "Late filing of accounts"}, nil
+				return []models.TransactionItem{
+					{TransactionID: "A123567", MadeUpDate: "2006-01-02", Reason: "Late filing of accounts"}}, nil
 			}
 
 			getConfig = mockedConfigGet
 			getCompanyName = mockedGetCompanyName
-			getTransactionForPenalty = mockedGetTransactionForPenalty
+			getPayablePenalty = mockedGetPayablePenalty
 
 			Convey("Then an error should be returned", func() {
 				_, err := prepareKafkaMessage(producerSchema, payableResource, req, penaltyDetailsMap, allowedTransactionsMap)

--- a/service/penalties.go
+++ b/service/penalties.go
@@ -74,24 +74,6 @@ func GetPenalties(companyNumber string, companyCode string, penaltyDetailsMap *c
 	return generatedTransactionListFromE5Response, Success, nil
 }
 
-// GetTransactionForPenalty returns a single, specified, transaction from e5 for a specific company
-func GetTransactionForPenalty(companyNumber, companyCode, penaltyReference string, penaltyDetailsMap *config.PenaltyDetailsMap,
-	allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListItem, error) {
-	response, _, err := getAccountPenalties(companyNumber, companyCode, penaltyDetailsMap, allowedTransactionsMap)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-
-	for _, transaction := range response.Items {
-		if transaction.ID == penaltyReference {
-			return &transaction, nil
-		}
-	}
-
-	return nil, fmt.Errorf("cannot find transaction for penalty reference [%v]", penaltyReference)
-}
-
 func generateTransactionListFromE5Response(e5Response *e5.GetTransactionsResponse, companyCode string,
 	penaltyDetailsMap *config.PenaltyDetailsMap, allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, error) {
 	// Next, map results to a format that can be used by PPS web

--- a/service/penalties_test.go
+++ b/service/penalties_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/companieshouse/penalty-payment-api-core/validators"
 	"github.com/companieshouse/penalty-payment-api/config"
 	"github.com/companieshouse/penalty-payment-api/e5"
-	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
 	"github.com/companieshouse/penalty-payment-api/mocks"
 	"github.com/companieshouse/penalty-payment-api/utils"
 
@@ -284,39 +283,6 @@ func TestUnitGetPenalties(t *testing.T) {
 		So(err, ShouldEqual, errGettingTransactions)
 		So(listResponse, ShouldBeNil)
 		So(responseType, ShouldEqual, Error)
-	})
-}
-
-func TestUnitGetTransactionForPenalty(t *testing.T) {
-	transactionListResponse := models.TransactionListResponse{}
-
-	Convey("error when transactions cannot be retrieved", t, func() {
-		errGettingTransactions := errors.New("error getting transactions")
-
-		mockedGetTransactions := func(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap,
-			allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, types.ResponseType, error) {
-			return &transactionListResponse, types.Error, errGettingTransactions
-		}
-
-		getAccountPenalties = mockedGetTransactions
-
-		_, err := GetTransactionForPenalty(companyNumber, utils.LateFilingPenalty, "A1234567", penaltyDetailsMap, allowedTransactionMap)
-		So(err, ShouldEqual, errGettingTransactions)
-	})
-
-	Convey("error when no transactions found for penalty reference", t, func() {
-		penaltyReference := "P1234567"
-		errGettingTransactions := errors.New("cannot find transaction for penalty reference [" + penaltyReference + "]")
-
-		mockedGetTransactions := func(companyNumber string, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap,
-			allowedTransactionsMap *models.AllowedTransactionMap) (*models.TransactionListResponse, types.ResponseType, error) {
-			return &transactionListResponse, types.Error, nil
-		}
-
-		getAccountPenalties = mockedGetTransactions
-
-		_, err := GetTransactionForPenalty(companyNumber, utils.Sanctions, penaltyReference, penaltyDetailsMap, allowedTransactionMap)
-		So(err, ShouldResemble, errGettingTransactions)
 	})
 }
 


### PR DESCRIPTION
* SendEmailKafkaMessage calls Issuer Gateway PayablePenalty in place of GetTransactionForPenalty.
* Unit test refactored to reflect the update.
* Refactored PayablePenalty/MatchPenalty to process a single transaction
