### PR TITLE
SAN-328 Upgrade Golang version to 1.24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,4 @@
 !go.mod
 !go.sum
 !main.go
+!bin/go_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,36 @@
-FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/golang:1.19-bullseye-builder AS builder
+FROM golang:1.24.2-bullseye as builder
+
+ENV GOPRIVATE="github.com/companieshouse"
+
+ARG SSH_PRIVATE_KEY
+ARG SSH_PRIVATE_KEY_PASSPHRASE
+
+COPY ./bin/go_build /bin/
+
+RUN chmod +x /bin/go_build && \
+    git config --global url."git@github.com:".insteadOf https://github.com/
+
+WORKDIR /build
+
+COPY . /build/
 
 RUN /bin/go_build
 
-FROM 169942020521.dkr.ecr.eu-west-2.amazonaws.com/base/golang:debian11-runtime
+FROM debian:bullseye
+
+RUN apt-get update && \
+    apt-get install -y --allow-downgrades --no-install-recommends\
+    ca-certificates=20210119 && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /app/
+
+WORKDIR /app
 
 COPY --from=builder /build/out/app ./
 
 COPY assets ./assets
+
+ENTRYPOINT ["/app/app"]
 
 CMD ["-bind-addr=:4086"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,7 @@ COPY . /build/
 
 RUN /bin/go_build
 
-FROM debian:bullseye
-
-RUN apt-get update && \
-    apt-get install -y --allow-downgrades --no-install-recommends\
-    ca-certificates=20210119 && \
-    rm -rf /var/lib/apt/lists/* && \
-    mkdir /app/
+FROM gcr.io/distroless/base-debian11 AS runner
 
 WORKDIR /app
 
@@ -30,8 +24,10 @@ COPY --from=builder /build/out/app ./
 
 COPY assets ./assets
 
-ENTRYPOINT ["/app/app"]
-
 CMD ["-bind-addr=:4086"]
 
 EXPOSE 4086
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/app/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . /build/
 
 RUN /bin/go_build
 
-FROM gcr.io/distroless/base-debian11 AS runner
+FROM gcr.io/distroless/base-debian11:latest@sha256:ac69aa622ea5dcbca0803ca877d47d069f51bd4282d5c96977e0390d7d256455 AS runner
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bullseye as builder
+FROM golang:1.24.2-bullseye AS builder
 
 ENV GOPRIVATE="github.com/companieshouse"
 

--- a/bin/go_build
+++ b/bin/go_build
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+mkdir -m 0600 ~/.ssh
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+echo "${SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa
+chmod 600 ~/.ssh/id_rsa
+ssh-keygen -p -f ~/.ssh/id_rsa -P "${SSH_PRIVATE_KEY_PASSPHRASE}" -N ""
+
+go mod download
+
+go fmt ./...
+
+go build -o /build/out/app

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/companieshouse/go-sdk-manager v0.1.12
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
-	github.com/companieshouse/penalty-payment-api-core v1.1.2
+	github.com/companieshouse/penalty-payment-api-core v1.11.1
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/jarcoal/httpmock v1.0.4
@@ -59,7 +59,7 @@ require (
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.35.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/companieshouse/penalty-payment-api
 
-go 1.19
+go 1.23.0
 
 require (
 	github.com/companieshouse/api-sdk-go v0.1.62

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/companieshouse/penalty-payment-api
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/companieshouse/api-sdk-go v0.1.62

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/companieshouse/gofigure v0.1.0/go.mod h1:W7NZ4kQdDXqvqK1f7EKTc+pnnqpF
 github.com/companieshouse/gofigure v0.1.4 h1:BN7Dqn0xvNHwC+KHOUHigwP7ajkfHORos3hKRtEACUU=
 github.com/companieshouse/gofigure v0.1.4/go.mod h1:lBAsI13q21rMce+pO7x4xUYAXzO0MchuDsZUbCs0Yng=
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
-github.com/companieshouse/penalty-payment-api-core v1.1.2 h1:00SlMHAwTyKJ/aeDEjyuXQWYNb7OVq90nwoXQza4SmY=
-github.com/companieshouse/penalty-payment-api-core v1.1.2/go.mod h1:9cqGa5ZlpwYqFh5NlqIJJK39G4p2wBdoWJkuVW8Ssxc=
+github.com/companieshouse/penalty-payment-api-core v1.11.1 h1:y+5qVKzV1zRt+w5Gs0aO5ZmiIn6vYN7HskSymSNbrak=
+github.com/companieshouse/penalty-payment-api-core v1.11.1/go.mod h1:4sT6uUinDGvzFz+yIJQ+8PW/E5twgK3VM5mFVplgENQ=
 github.com/companieshouse/private-api-sdk-go v0.1.11/go.mod h1:EaRgxVpcHv6IZ1LKp2xqE4rdEsQwgYqVz3g/BIHQVD4=
 github.com/companieshouse/private-api-sdk-go v0.1.13 h1:o9PD1aSVu3+tbf/WUZT/wX1e0DNx+9xcJugbqo7rbxE=
 github.com/companieshouse/private-api-sdk-go v0.1.13/go.mod h1:g1zvBCn8Tyc45x+5BmlHsq+BYwuekd5FLRaFOqTUu+A=
@@ -206,8 +206,8 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -238,6 +239,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
 gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hrEw=


### PR DESCRIPTION
* Upgrade Golang version from 1.19 to 1.24.2
* Removed dependency on [golang-base-image](https://github.com/companieshouse/golang-base-image) in the Dockerfile as version 1.24.2 of the image is not available
* Updated Dockerfile to use Golang builder 1.24.2

Depends on https://github.com/companieshouse/penalty-payment-api-core/pull/33