### PR TITLE
SAN-409 Update TTL logic to be determined only based on PPS_ACCOUNT_P…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ In order to run this API locally you will need to install the following:
 | `PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION`      |   `-`   | The collection name e.g. `payable_resources`                                                      |
 | `PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION`      |   `-`   | The collection name e.g. `account_penalties`                                                      |
 | `PPS_ACCOUNT_PENALTIES_TTL`                     |   `-`   | Account penalties cache time to live  e.g. `24h`                                                  |
-| `E5_ALLOCATION_ROUTINE_DURATION`                |   `-`   | Duration for a complete E5 allocation routine run  e.g. `4h`                                      |
-| `E5_ALLOCATION_ROUTINE_START_HOUR`              |   `-`   | A number representing the hour of the day when E5 allocation routine starts  e.g. `20` (for 8 pm) |
 | `KAFKA_BROKER_ADDR`                             |   `_`   | Kafka Broker Address                                                                              |
 | `SCHEMA_REGISTRY_URL`                           |   `_`   | Schema Registry URL                                                                               |
 | `API_URL`                                       |   `_`   | The application endpoint for the API, for go-sdk-manager integration                              |

--- a/config/config.go
+++ b/config/config.go
@@ -17,24 +17,22 @@ var mtx sync.Mutex
 
 // Config defines the configuration options for this service.
 type Config struct {
-	BindAddr                     string       `env:"BIND_ADDR"                                flag:"bind-addr"                            flagDesc:"Bind address"`
-	E5APIURL                     string       `env:"E5_API_URL"                               flag:"e5-api-url"                           flagDesc:"Base URL for the E5 API"`
-	E5Username                   string       `env:"E5_USERNAME"                              flag:"e5-username"                          flagDesc:"Username for the E5 API"`
-	MongoDBURL                   string       `env:"MONGODB_URL"                              flag:"mongodb-url"                          flagDesc:"MongoDB server URL"`
-	Database                     string       `env:"PPS_MONGODB_DATABASE"                     flag:"mongodb-database"                     flagDesc:"MongoDB database for data"`
-	PayableResourcesCollection   string       `env:"PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION" flag:"mongodb-payable-resources-collection" flagDesc:"The name of the mongodb payable resources collection"`
-	AccountPenaltiesCollection   string       `env:"PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION" flag:"mongodb-account-penalties-collection" flagDesc:"The name of the mongodb account penalties collection"`
-	AccountPenaltiesTTL          string       `env:"PPS_ACCOUNT_PENALTIES_TTL"                flag:"account-penalties-ttl"                flagDesc:"The time to live for account penalties cache entry"`
-	E5AllocationRoutineDuration  string       `env:"E5_ALLOCATION_ROUTINE_DURATION"           flag:"e5-allocation-routine-duration"       flagDesc:"The duration for a complete e5 allocation routine run"`
-	E5AllocationRoutineStartHour int          `env:"E5_ALLOCATION_ROUTINE_START_HOUR"         flag:"e5-allocation-routine-start-hour"     flagDesc:"The hour of the day when e5 allocation routine starts"`
-	BrokerAddr                   []string     `env:"KAFKA_BROKER_ADDR"                        flag:"broker-addr"                          flagDesc:"Kafka broker address"`
-	SchemaRegistryURL            string       `env:"SCHEMA_REGISTRY_URL"                      flag:"schema-registry-url"                  flagDesc:"Schema registry url"`
-	CHSURL                       string       `env:"CHS_URL"                                  flag:"chs-url"                              flagDesc:"CHS URL"`
-	WeeklyMaintenanceStartTime   string       `env:"WEEKLY_MAINTENANCE_START_TIME"            flag:"weekly-maintenance-start-time"        flagDesc:"The time of the day when Weekly E5 maintenance starts"`
-	WeeklyMaintenanceEndTime     string       `env:"WEEKLY_MAINTENANCE_END_TIME"              flag:"weekly-maintenance-end-time"          flagDesc:"The time of the day when Weekly E5 maintenance ends"`
-	WeeklyMaintenanceDay         time.Weekday `env:"WEEKLY_MAINTENANCE_DAY"                   flag:"weekly-maintenance-day"               flagDesc:"The day on which Weekly E5 maintenance takes place"`
-	PlannedMaintenanceStart      string       `env:"PLANNED_MAINTENANCE_START_TIME"           flag:"planned-maintenance-start-time"       flagDesc:"The time of the day at which Planned E5 maintenance starts"`
-	PlannedMaintenanceEnd        string       `env:"PLANNED_MAINTENANCE_END_TIME"             flag:"planned-maintenance-end-time"         flagDesc:"The time of the day at which Planned E5 maintenance ends"`
+	BindAddr                   string       `env:"BIND_ADDR"                                flag:"bind-addr"                            flagDesc:"Bind address"`
+	E5APIURL                   string       `env:"E5_API_URL"                               flag:"e5-api-url"                           flagDesc:"Base URL for the E5 API"`
+	E5Username                 string       `env:"E5_USERNAME"                              flag:"e5-username"                          flagDesc:"Username for the E5 API"`
+	MongoDBURL                 string       `env:"MONGODB_URL"                              flag:"mongodb-url"                          flagDesc:"MongoDB server URL"`
+	Database                   string       `env:"PPS_MONGODB_DATABASE"                     flag:"mongodb-database"                     flagDesc:"MongoDB database for data"`
+	PayableResourcesCollection string       `env:"PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION" flag:"mongodb-payable-resources-collection" flagDesc:"The name of the mongodb payable resources collection"`
+	AccountPenaltiesCollection string       `env:"PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION" flag:"mongodb-account-penalties-collection" flagDesc:"The name of the mongodb account penalties collection"`
+	AccountPenaltiesTTL        string       `env:"PPS_ACCOUNT_PENALTIES_TTL"                flag:"account-penalties-ttl"                flagDesc:"The time to live for account penalties cache entry"`
+	BrokerAddr                 []string     `env:"KAFKA_BROKER_ADDR"                        flag:"broker-addr"                          flagDesc:"Kafka broker address"`
+	SchemaRegistryURL          string       `env:"SCHEMA_REGISTRY_URL"                      flag:"schema-registry-url"                  flagDesc:"Schema registry url"`
+	CHSURL                     string       `env:"CHS_URL"                                  flag:"chs-url"                              flagDesc:"CHS URL"`
+	WeeklyMaintenanceStartTime string       `env:"WEEKLY_MAINTENANCE_START_TIME"            flag:"weekly-maintenance-start-time"        flagDesc:"The time of the day when Weekly E5 maintenance starts"`
+	WeeklyMaintenanceEndTime   string       `env:"WEEKLY_MAINTENANCE_END_TIME"              flag:"weekly-maintenance-end-time"          flagDesc:"The time of the day when Weekly E5 maintenance ends"`
+	WeeklyMaintenanceDay       time.Weekday `env:"WEEKLY_MAINTENANCE_DAY"                   flag:"weekly-maintenance-day"               flagDesc:"The day on which Weekly E5 maintenance takes place"`
+	PlannedMaintenanceStart    string       `env:"PLANNED_MAINTENANCE_START_TIME"           flag:"planned-maintenance-start-time"       flagDesc:"The time of the day at which Planned E5 maintenance starts"`
+	PlannedMaintenanceEnd      string       `env:"PLANNED_MAINTENANCE_END_TIME"             flag:"planned-maintenance-end-time"         flagDesc:"The time of the day at which Planned E5 maintenance ends"`
 }
 
 // PenaltyDetailsMap defines the struct to hold the map of penalty details.

--- a/issuer_gateway/api/account_penalties_test.go
+++ b/issuer_gateway/api/account_penalties_test.go
@@ -159,8 +159,6 @@ var e5TransactionsResponse = e5.GetTransactionsResponse{
 func TestUnitAccountPenalties(t *testing.T) {
 	cfg, _ := config.Get()
 	cfg.AccountPenaltiesTTL = "24h"
-	cfg.E5AllocationRoutineDuration = "4h"
-	cfg.E5AllocationRoutineStartHour = 20
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -306,7 +304,6 @@ func TestUnitAccountPenalties(t *testing.T) {
 		So(responseType, ShouldEqual, services.Success)
 	})
 
-	// This test will fail between 8pm and 12.00am.
 	Convey("cache updated and penalties returned when stale transactions in cache (PayableStatus = CLOSED)", t, func() {
 		accountPenalties, transactionsResponse := createData(true, true)
 
@@ -409,7 +406,7 @@ func assertTransactionListItem(transactionListItem models.TransactionListItem, e
 }
 
 func createData(isPaid bool, isStale bool) (models.AccountPenaltiesDao, e5.GetTransactionsResponse) {
-	createdAt := time.Now().Add(time.Minute * 10)
+	createdAt := time.Now().Add(time.Hour * -6)
 	if isStale {
 		createdAt = time.Now().Add(-24 * time.Hour)
 	}


### PR DESCRIPTION
Update Time To Live (TTL) logic to be determined only based on PPS_ACCOUNT_PENALTIES_TTL environment variable

* Before this update, we determined a stale cache in two ways: first, based on a fixed TTL set at 24hours by default, and second, based on an estimated execution window for E5 allocation routine, which defaults to 8pm to 12am daily.
* This patch simplifies the logic to determine a stale cache by limiting it to the fixed TTL set at 24 hours by default.
* TTL starts counting from the time a cache record is updated with payment information `ClosedAt`, and is pending payment allocation (`ClosedAt != nil`).
* TTL starts counting from the time a cache record is created `CreatedAt` if not pending payment allocation (`ClosedAt == nil`)