### PR TITLE
SAN-494 Address bug in logic to determine penalties in "closed_pending_allocation" state

### DIFF
--- a/issuer_gateway/api/account_penalties_test.go
+++ b/issuer_gateway/api/account_penalties_test.go
@@ -232,17 +232,10 @@ func TestUnitAccountPenalties(t *testing.T) {
 	})
 
 	Convey("penalties returned when valid transactions returned from cache (payableStatus = OPEN)", t, func() {
-		accountPenalties, transactionsResponse := createData(false, false)
+		accountPenalties, _ := createData(false, false)
 
 		mockApDaoSvc := mocks.NewMockAccountPenaltiesDaoService(ctrl)
 		mockApDaoSvc.EXPECT().GetAccountPenalties(customerCode, companyCode).Return(&accountPenalties, nil)
-
-		mockedGetTransactions := func(customerCode string, companyCode string,
-			client *e5.Client) (*e5.GetTransactionsResponse, error) {
-			return &transactionsResponse, nil
-		}
-
-		getTransactions = mockedGetTransactions
 
 		listResponse, responseType, err := AccountPenalties(penaltyRefType, customerCode, companyCode,
 			penaltyDetailsMap, allowedTransactionMap, mockApDaoSvc)
@@ -254,17 +247,11 @@ func TestUnitAccountPenalties(t *testing.T) {
 
 	Convey("penalties returned when valid transactions returned from cache (payableStatus = CLOSED_PENDING_ALLOCATION)", t, func() {
 
-		accountPenalties, transactionsResponse := createData(true, false)
+		accountPenalties, _ := createData(true, false)
+		accountPenalties.AccountPenalties[0].OutstandingAmount = 250.0
 
 		mockApDaoSvc := mocks.NewMockAccountPenaltiesDaoService(ctrl)
 		mockApDaoSvc.EXPECT().GetAccountPenalties(customerCode, companyCode).Return(&accountPenalties, nil)
-
-		mockedGetTransactions := func(customerCode string, companyCode string,
-			client *e5.Client) (*e5.GetTransactionsResponse, error) {
-			return &transactionsResponse, nil
-		}
-
-		getTransactions = mockedGetTransactions
 
 		listResponse, responseType, err := AccountPenalties(penaltyRefType, customerCode, companyCode,
 			penaltyDetailsMap, allowedTransactionMap, mockApDaoSvc)
@@ -319,12 +306,12 @@ func TestUnitAccountPenalties(t *testing.T) {
 		// should default to 24h when unparsable value passed
 		cfg.AccountPenaltiesTTL = "24hhn"
 		accountPenalties, transactionsResponse := createData(true, true)
+		accountPenalties.AccountPenalties[0].OutstandingAmount = 250.0
 
 		mockPenaltiesService := mocks.NewMockAccountPenaltiesDaoService(ctrl)
 		mockPenaltiesService.EXPECT().GetAccountPenalties(customerCode, companyCode).Return(&accountPenalties, nil)
 		mockPenaltiesService.EXPECT().UpdateAccountPenalties(gomock.Any()).Return(nil)
 
-		e5TransactionsResponse.Transactions[0].IsPaid = true
 		getTransactions = func(customerCode string, companyCode string,
 			client *e5.Client) (*e5.GetTransactionsResponse, error) {
 			return &transactionsResponse, nil

--- a/issuer_gateway/private/generate_transaction_list.go
+++ b/issuer_gateway/private/generate_transaction_list.go
@@ -151,7 +151,8 @@ func getPayableStatus(transactionType string, e5Transaction *models.AccountPenal
 func checkClosedPayableStatus(penalty *models.AccountPenaltiesDataDao, closedAt *time.Time,
 	e5Transactions []models.AccountPenaltiesDataDao, allowedTransactionsMap *models.AllowedTransactionMap) (payableStatus string, isClosed bool) {
 	if (penalty.IsPaid && closedAt != nil) &&
-		penaltyPaidToday(closedAt) {
+		penaltyPaidToday(closedAt) &&
+		!penaltyPaymentAllocated(penalty) {
 		return ClosedPendingAllocationPayableStatus, true
 	}
 
@@ -196,4 +197,10 @@ func penaltyPaidToday(closedAt *time.Time) bool {
 
 func checkDunningStatus(transaction *models.AccountPenaltiesDataDao, dunningStatus string) bool {
 	return strings.TrimSpace(transaction.DunningStatus) == dunningStatus
+}
+
+func penaltyPaymentAllocated(penalty *models.AccountPenaltiesDataDao) bool {
+	// The value of outstanding amount is 0 after penalty payment is allocated in E5
+	// and AccountPenalties cache is updated with E5 data
+	return penalty.OutstandingAmount == 0
 }

--- a/issuer_gateway/private/generate_transaction_list_test.go
+++ b/issuer_gateway/private/generate_transaction_list_test.go
@@ -1112,6 +1112,18 @@ func TestUnit_getPayableStatus(t *testing.T) {
 			})
 		}
 	})
+
+	Convey("Get closed payable status for an existing paid penalty from E5 in the same account as a newly paid penalty", t, func() {
+		oldPaidPenalty := createRoePenalty(true, 0, CHSAccountStatus,
+			addTrailingSpacesToDunningStatus(PEN1DunningStatus))
+		newPaidPenalty := createRoePenalty(true, 250, CHSAccountStatus,
+			addTrailingSpacesToDunningStatus(PEN1DunningStatus))
+
+		closedAt := time.Now()
+		got := getPayableStatus(types.Penalty.String(), oldPaidPenalty, &closedAt, []models.AccountPenaltiesDataDao{*oldPaidPenalty, *newPaidPenalty}, allowedTransactionMap)
+
+		So(got, ShouldEqual, ClosedPayableStatus)
+	})
 }
 
 func createLateFilingPenalty(isPaid bool, outstandingAmount float64, accountStatus, dunningStatus string) *models.AccountPenaltiesDataDao {

--- a/issuer_gateway/private/generate_transaction_list_test.go
+++ b/issuer_gateway/private/generate_transaction_list_test.go
@@ -1120,9 +1120,11 @@ func TestUnit_getPayableStatus(t *testing.T) {
 			addTrailingSpacesToDunningStatus(PEN1DunningStatus))
 
 		closedAt := time.Now()
-		got := getPayableStatus(types.Penalty.String(), oldPaidPenalty, &closedAt, []models.AccountPenaltiesDataDao{*oldPaidPenalty, *newPaidPenalty}, allowedTransactionMap)
+		e5Transactions := []models.AccountPenaltiesDataDao{*oldPaidPenalty, *newPaidPenalty}
 
-		So(got, ShouldEqual, ClosedPayableStatus)
+		So(getPayableStatus(types.Penalty.String(), oldPaidPenalty, &closedAt, e5Transactions, allowedTransactionMap), ShouldEqual, ClosedPayableStatus)
+		So(getPayableStatus(types.Penalty.String(), newPaidPenalty, &closedAt, e5Transactions, allowedTransactionMap), ShouldEqual, ClosedPendingAllocationPayableStatus)
+
 	})
 }
 


### PR DESCRIPTION
This patch addresses the scenario where a paid penalty already updated in E5 exists along side a newly paid penalty yet to be updated in E5. The expected payable states for these two penalties are:
Old paid penalty: CLOSED
Newly paid penalty: CLOSED_PENDING_ALLOCATION
However, prior to this patch, both penalties share the same state, CLOSED_PENDING_ALLOCATION.
With this patch, the penalties are set to the correct and expected states.