### PR TITLE
SAN-428: Add retry for transient E5 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,30 +13,33 @@ In order to run this API locally you will need to install the following:
 2. Build the executable: `make build`
 
 ## Configuration
-| Variable                                   | Default | Description                                                                 | Config Location                                                           |
-|:-------------------------------------------|:-------:|:----------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| `API_KEY`                                  |   `-`   | API Key to call payments API                                                | Terraform Vault - To update, please create platform request               |
-| `E5_USERNAME`                              |   `-`   | E5 API Username                                                             | Terraform Vault - To update, please create platform request               |
-| `MONGODB_URL`                              |   `-`   | The mongo db connection string                                              | Terraform Vault - To update, please create platform request               |
-| `E5_API_URL`                               |   `-`   | E5 API Address                                                              | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PPS_MONGODB_DATABASE`                     |   `-`   | The database name to connect to e.g. `financial_penalties`                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION` |   `-`   | The collection name e.g. `payable_resources`                                | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION` |   `-`   | The collection name e.g. `account_penalties`                                | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PPS_ACCOUNT_PENALTIES_TTL`                |   `-`   | Account penalties cache time to live  e.g. `24h`                            | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `KAFKA_BROKER_ADDR`                        |   `_`   | Kafka Broker Address                                                        | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `KAFKA_ZOOKEEPER_ADDR`                     |   `_`   | Kafka Zookeeper Address                                                     | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `SCHEMA_REGISTRY_URL`                      |   `_`   | Schema Registry URL                                                         | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `EMAIL_SEND_TOPIC`                         |   `_`   | Kafka topic to send emails e.g. email-send                                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PENALTY_PAYMENTS_PROCESSING_TOPIC`        |   `_`   | Kafka topic to process penalty payments to e.g. penalty-payments-processing | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `FEATURE_FLAG_PAYMENTS_PROCESSING_ENABLED` |   `_`   | If the payments processing Kafka implementation is enabled                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `API_URL`                                  |   `_`   | The application endpoint for the API, for go-sdk-manager integration        | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PAYMENTS_API_URL`                         |   `_`   | The base path for the payments API, for go-sdk-manager integration          | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `CHS_URL`                                  |   `_`   | CHS URL                                                                     | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `WEEKLY_MAINTENANCE_START_TIME`            |   `_`   | Start time of weekly maintenance e.g. `0700`                                | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `WEEKLY_MAINTENANCE_END_TIME`              |   `_`   | End time of weekly maintenance e.g. `0730`                                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `WEEKLY_MAINTENANCE_DAY`                   |   `_`   | Day of weekly maintenance e.g. `0` (zero for Sunday)                        | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PLANNED_MAINTENANCE_START_TIME`           |   `_`   | Start time and date of planned maintenance e.g. `01 Jan 19 15:04 BST`       | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
-| `PLANNED_MAINTENANCE_END_TIME`             |   `_`   | End time and date of planned maintenance e.g. `31 Jan 19 16:59 BST`         | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| Variable                                      | Default | Description                                                                 | Config Location                                                           |
+|:----------------------------------------------|:-------:|:----------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| `API_KEY`                                     |   `-`   | API Key to call payments API                                                | Terraform Vault - To update, please create platform request               |
+| `E5_USERNAME`                                 |   `-`   | E5 API Username                                                             | Terraform Vault - To update, please create platform request               |
+| `MONGODB_URL`                                 |   `-`   | The mongo db connection string                                              | Terraform Vault - To update, please create platform request               |
+| `E5_API_URL`                                  |   `-`   | E5 API Address                                                              | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PPS_MONGODB_DATABASE`                        |   `-`   | The database name to connect to e.g. `financial_penalties`                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION`    |   `-`   | The collection name e.g. `payable_resources`                                | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION`    |   `-`   | The collection name e.g. `account_penalties`                                | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PPS_ACCOUNT_PENALTIES_TTL`                   |   `-`   | Account penalties cache time to live  e.g. `24h`                            | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `KAFKA_BROKER_ADDR`                           |   `_`   | Kafka Broker Address                                                        | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `KAFKA_ZOOKEEPER_ADDR`                        |   `_`   | Kafka Zookeeper Address                                                     | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `SCHEMA_REGISTRY_URL`                         |   `_`   | Schema Registry URL                                                         | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `EMAIL_SEND_TOPIC`                            |   `_`   | Kafka topic to send emails e.g. email-send                                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PENALTY_PAYMENTS_PROCESSING_TOPIC`           |   `_`   | Kafka topic to process penalty payments to e.g. penalty-payments-processing | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PENALTY_PAYMENTS_PROCESSING_MAX_RETRIES`     |   `_`   | The max retry attempts for transient errors to e.g. 3                       | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PENALTY_PAYMENTS_PROCESSING_RETRY_DELAY`     |   `_`   | The delay in seconds between retry attempts for transient errors to e.g. 1  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PENALTY_PAYMENTS_PROCESSING_RETRY_MAX_DELAY` |   `_`   | The maximum delay time in seconds between retries for transient errors      | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `FEATURE_FLAG_PAYMENTS_PROCESSING_ENABLED`    |   `_`   | If the payments processing Kafka implementation is enabled                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `API_URL`                                     |   `_`   | The application endpoint for the API, for go-sdk-manager integration        | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PAYMENTS_API_URL`                            |   `_`   | The base path for the payments API, for go-sdk-manager integration          | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `CHS_URL`                                     |   `_`   | CHS URL                                                                     | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `WEEKLY_MAINTENANCE_START_TIME`               |   `_`   | Start time of weekly maintenance e.g. `0700`                                | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `WEEKLY_MAINTENANCE_END_TIME`                 |   `_`   | End time of weekly maintenance e.g. `0730`                                  | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `WEEKLY_MAINTENANCE_DAY`                      |   `_`   | Day of weekly maintenance e.g. `0` (zero for Sunday)                        | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PLANNED_MAINTENANCE_START_TIME`              |   `_`   | Start time and date of planned maintenance e.g. `01 Jan 19 15:04 BST`       | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
+| `PLANNED_MAINTENANCE_END_TIME`                |   `_`   | End time and date of planned maintenance e.g. `31 Jan 19 16:59 BST`         | ecs-service-configs-dev(CIDEV) / ecs-service-configs-prod (STAGING/LIVE)  |
 
 ## Endpoints
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,26 +17,29 @@ var mtx sync.Mutex
 
 // Config defines the configuration options for this service.
 type Config struct {
-	BindAddr                             string       `env:"BIND_ADDR"                                    flag:"bind-addr"                                flagDesc:"Bind address"`
-	E5APIURL                             string       `env:"E5_API_URL"                                   flag:"e5-api-url"                               flagDesc:"Base URL for the E5 API"`
-	E5Username                           string       `env:"E5_USERNAME"                                  flag:"e5-username"                              flagDesc:"Username for the E5 API"`
-	MongoDBURL                           string       `env:"MONGODB_URL"                                  flag:"mongodb-url"                              flagDesc:"MongoDB server URL"`
-	Database                             string       `env:"PPS_MONGODB_DATABASE"                         flag:"mongodb-database"                         flagDesc:"MongoDB database for data"`
-	PayableResourcesCollection           string       `env:"PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION"     flag:"mongodb-payable-resources-collection"     flagDesc:"The name of the mongodb payable resources collection"`
-	AccountPenaltiesCollection           string       `env:"PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION"     flag:"mongodb-account-penalties-collection"     flagDesc:"The name of the mongodb account penalties collection"`
-	AccountPenaltiesTTL                  string       `env:"PPS_ACCOUNT_PENALTIES_TTL"                    flag:"account-penalties-ttl"                    flagDesc:"The time to live for account penalties cache entry"`
-	BrokerAddr                           []string     `env:"KAFKA_BROKER_ADDR"                            flag:"broker-addr"                              flagDesc:"Kafka broker address"`
-	ZookeeperURL                         string       `env:"KAFKA_ZOOKEEPER_ADDR"                         flag:"zookeeper-addr"                           flagDesc:"Main CH Zookeeper address"`
-	SchemaRegistryURL                    string       `env:"SCHEMA_REGISTRY_URL"                          flag:"schema-registry-url"                      flagDesc:"Schema registry url"`
-	EmailSendTopic                       string       `env:"EMAIL_SEND_TOPIC"                             flag:"email-send-topic"                         flagDesc:"Kafka topic to send emails"`
-	PenaltyPaymentsProcessingTopic       string       `env:"PENALTY_PAYMENTS_PROCESSING_TOPIC"            flag:"penalty-payments-processing-topic"        flagDesc:"Penalty payments processing topic"`
-	FeatureFlagPaymentsProcessingEnabled bool         `env:"FEATURE_FLAG_PAYMENTS_PROCESSING_ENABLED"     flag:"feature-flag-payments-processing-enabled" flagDesc:"If the payments processing Kafka implementation is enabled"`
-	CHSURL                               string       `env:"CHS_URL"                                      flag:"chs-url"                                  flagDesc:"CHS URL"`
-	WeeklyMaintenanceStartTime           string       `env:"WEEKLY_MAINTENANCE_START_TIME"                flag:"weekly-maintenance-start-time"            flagDesc:"The time of the day when Weekly E5 maintenance starts"`
-	WeeklyMaintenanceEndTime             string       `env:"WEEKLY_MAINTENANCE_END_TIME"                  flag:"weekly-maintenance-end-time"              flagDesc:"The time of the day when Weekly E5 maintenance ends"`
-	WeeklyMaintenanceDay                 time.Weekday `env:"WEEKLY_MAINTENANCE_DAY"                       flag:"weekly-maintenance-day"                   flagDesc:"The day on which Weekly E5 maintenance takes place"`
-	PlannedMaintenanceStart              string       `env:"PLANNED_MAINTENANCE_START_TIME"               flag:"planned-maintenance-start-time"           flagDesc:"The time of the day at which Planned E5 maintenance starts"`
-	PlannedMaintenanceEnd                string       `env:"PLANNED_MAINTENANCE_END_TIME"                 flag:"planned-maintenance-end-time"             flagDesc:"The time of the day at which Planned E5 maintenance ends"`
+	BindAddr                               string       `env:"BIND_ADDR"                                    flag:"bind-addr"                                flagDesc:"Bind address"`
+	E5APIURL                               string       `env:"E5_API_URL"                                   flag:"e5-api-url"                               flagDesc:"Base URL for the E5 API"`
+	E5Username                             string       `env:"E5_USERNAME"                                  flag:"e5-username"                              flagDesc:"Username for the E5 API"`
+	MongoDBURL                             string       `env:"MONGODB_URL"                                  flag:"mongodb-url"                              flagDesc:"MongoDB server URL"`
+	Database                               string       `env:"PPS_MONGODB_DATABASE"                         flag:"mongodb-database"                         flagDesc:"MongoDB database for data"`
+	PayableResourcesCollection             string       `env:"PPS_MONGODB_PAYABLE_RESOURCES_COLLECTION"     flag:"mongodb-payable-resources-collection"     flagDesc:"The name of the mongodb payable resources collection"`
+	AccountPenaltiesCollection             string       `env:"PPS_MONGODB_ACCOUNT_PENALTIES_COLLECTION"     flag:"mongodb-account-penalties-collection"     flagDesc:"The name of the mongodb account penalties collection"`
+	AccountPenaltiesTTL                    string       `env:"PPS_ACCOUNT_PENALTIES_TTL"                    flag:"account-penalties-ttl"                    flagDesc:"The time to live for account penalties cache entry"`
+	BrokerAddr                             []string     `env:"KAFKA_BROKER_ADDR"                            flag:"broker-addr"                              flagDesc:"Kafka broker address"`
+	ZookeeperURL                           string       `env:"KAFKA_ZOOKEEPER_ADDR"                         flag:"zookeeper-addr"                           flagDesc:"Main CH Zookeeper address"`
+	SchemaRegistryURL                      string       `env:"SCHEMA_REGISTRY_URL"                          flag:"schema-registry-url"                      flagDesc:"Schema registry url"`
+	EmailSendTopic                         string       `env:"EMAIL_SEND_TOPIC"                             flag:"email-send-topic"                         flagDesc:"Kafka topic to send emails"`
+	PenaltyPaymentsProcessingTopic         string       `env:"PENALTY_PAYMENTS_PROCESSING_TOPIC"            flag:"penalty-payments-processing-topic"        flagDesc:"Penalty payments processing topic"`
+	PenaltyPaymentsProcessingMaxRetries    string       `env:"PENALTY_PAYMENTS_PROCESSING_MAX_RETRIES"      flag:"penalty-payments-processing-max-retries"  flagDesc:"Penalty payments processing max retry attempts for transient errors"`
+	PenaltyPaymentsProcessingRetryDelay    string       `env:"PENALTY_PAYMENTS_PROCESSING_RETRY_DELAY"      flag:"penalty-payments-processing-retry-delay"  flagDesc:"Penalty payments processing retry delay for transient errors"`
+	PenaltyPaymentsProcessingRetryMaxDelay string       `env:"PENALTY_PAYMENTS_PROCESSING_RETRY_MAX_DELAY"  flag:"penalty-payments-processing-max-delay"    flagDesc:"Penalty payments processing max delay for a retry attempt for transient errors"`
+	FeatureFlagPaymentsProcessingEnabled   bool         `env:"FEATURE_FLAG_PAYMENTS_PROCESSING_ENABLED"     flag:"feature-flag-payments-processing-enabled" flagDesc:"If the payments processing Kafka implementation is enabled"`
+	CHSURL                                 string       `env:"CHS_URL"                                      flag:"chs-url"                                  flagDesc:"CHS URL"`
+	WeeklyMaintenanceStartTime             string       `env:"WEEKLY_MAINTENANCE_START_TIME"                flag:"weekly-maintenance-start-time"            flagDesc:"The time of the day when Weekly E5 maintenance starts"`
+	WeeklyMaintenanceEndTime               string       `env:"WEEKLY_MAINTENANCE_END_TIME"                  flag:"weekly-maintenance-end-time"              flagDesc:"The time of the day when Weekly E5 maintenance ends"`
+	WeeklyMaintenanceDay                   time.Weekday `env:"WEEKLY_MAINTENANCE_DAY"                       flag:"weekly-maintenance-day"                   flagDesc:"The day on which Weekly E5 maintenance takes place"`
+	PlannedMaintenanceStart                string       `env:"PLANNED_MAINTENANCE_START_TIME"               flag:"planned-maintenance-start-time"           flagDesc:"The time of the day at which Planned E5 maintenance starts"`
+	PlannedMaintenanceEnd                  string       `env:"PLANNED_MAINTENANCE_END_TIME"                 flag:"planned-maintenance-end-time"             flagDesc:"The time of the day at which Planned E5 maintenance ends"`
 }
 
 // PenaltyDetailsMap defines the struct to hold the map of penalty details.

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.24
 
 require (
 	github.com/Shopify/sarama v1.24.0
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/companieshouse/api-sdk-go v0.1.62
 	github.com/companieshouse/chs.go v1.2.14-rbull3
 	github.com/companieshouse/filing-notification-sender v2.0.0-rc3+incompatible
 	github.com/companieshouse/go-sdk-manager v0.1.12
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
-	github.com/companieshouse/penalty-payment-api-core v1.12.1
+	github.com/companieshouse/penalty-payment-api-core v1.12.2
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/jarcoal/httpmock v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/Shopify/sarama v1.24.0 h1:99vo5VAgQybHwZwiOy/RX/S3i0somjGxur3pLeheqzI
 github.com/Shopify/sarama v1.24.0/go.mod h1:fGP8eQ6PugKEI0iUETYYtnP6d1pH/bdDMTel1X5ajsU=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/bsm/sarama-cluster v2.1.15+incompatible h1:RkV6WiNRnqEEbp81druK8zYhmnIgdOjqSVi0+9Cnl2A=
 github.com/bsm/sarama-cluster v2.1.15+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -43,6 +45,8 @@ github.com/companieshouse/gofigure v0.1.4/go.mod h1:lBAsI13q21rMce+pO7x4xUYAXzO0
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
 github.com/companieshouse/penalty-payment-api-core v1.12.1 h1:fVZ5kdhz3bKcIPx9bfdDN8ITSEM7BY8o+dtyMfgEoSk=
 github.com/companieshouse/penalty-payment-api-core v1.12.1/go.mod h1:4sT6uUinDGvzFz+yIJQ+8PW/E5twgK3VM5mFVplgENQ=
+github.com/companieshouse/penalty-payment-api-core v1.12.2 h1:j2BMh4GpHCqOcNa+iHOwg153iUIO/0S0zNGZHFXDsM4=
+github.com/companieshouse/penalty-payment-api-core v1.12.2/go.mod h1:4sT6uUinDGvzFz+yIJQ+8PW/E5twgK3VM5mFVplgENQ=
 github.com/companieshouse/private-api-sdk-go v0.1.11/go.mod h1:EaRgxVpcHv6IZ1LKp2xqE4rdEsQwgYqVz3g/BIHQVD4=
 github.com/companieshouse/private-api-sdk-go v0.1.13 h1:o9PD1aSVu3+tbf/WUZT/wX1e0DNx+9xcJugbqo7rbxE=
 github.com/companieshouse/private-api-sdk-go v0.1.13/go.mod h1:g1zvBCn8Tyc45x+5BmlHsq+BYwuekd5FLRaFOqTUu+A=

--- a/handlers/create_payable_resource.go
+++ b/handlers/create_payable_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/companieshouse/penalty-payment-api/penalty_payments/transformers"
 )
 
-var getCompanyCodeFromTransaction = utils.GetCompanyCodeFromTransaction
 var payablePenalty = api.PayablePenalty
 
 // CreatePayableResourceHandler takes a http requests and creates a new payable resource

--- a/handlers/finance_payment.go
+++ b/handlers/finance_payment.go
@@ -1,15 +1,22 @@
 package handlers
 
 import (
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/avast/retry-go"
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/penalty-payment-api-core/models"
 	"github.com/companieshouse/penalty-payment-api/common/dao"
 	"github.com/companieshouse/penalty-payment-api/common/e5"
+	"github.com/companieshouse/penalty-payment-api/config"
 )
 
 // FinancePayment interface declares the processing handler for the consumer
 type FinancePayment interface {
-	ProcessFinancialPenaltyPayment(penaltyPayment models.PenaltyPaymentsProcessing, e5PaymentID string) error
+	ProcessFinancialPenaltyPayment(penaltyPayment models.PenaltyPaymentsProcessing, e5PaymentID string,
+		cfg *config.Config) error
 }
 
 // PenaltyFinancePayment is the processing handler for the consumer
@@ -23,7 +30,8 @@ type PenaltyFinancePayment struct {
 // the payments and finally 3) confirm the payment. If any one of these fails, the company account will be locked in
 // E5. Finance have confirmed that it is better to keep these locked as a cleanup process will happen naturally in
 // the working day.
-func (p PenaltyFinancePayment) ProcessFinancialPenaltyPayment(penaltyPayment models.PenaltyPaymentsProcessing, e5PaymentID string) error {
+func (p PenaltyFinancePayment) ProcessFinancialPenaltyPayment(penaltyPayment models.PenaltyPaymentsProcessing,
+	e5PaymentID string, cfg *config.Config) error {
 	logContext := log.Data{
 		"customer_code":           penaltyPayment.CustomerCode,
 		"company_code":            penaltyPayment.CompanyCode,
@@ -33,26 +41,147 @@ func (p PenaltyFinancePayment) ProcessFinancialPenaltyPayment(penaltyPayment mod
 	}
 	log.Info("Financial penalty payment processing started", logContext)
 
-	createPaymentError, createPaymentSuccess := createPayment(penaltyPayment, p.PayableResourceDaoService, p.E5Client, e5PaymentID)
-	if !createPaymentSuccess {
-		return createPaymentError
+	if isAfterNextDayMidnight(penaltyPayment.CreatedAt) {
+		log.Info("Skipping financial penalty payment processing as current time is after next day midnight of created_at", logContext)
+		return nil
 	}
 
-	authorisePaymentError, authorisePaymentSuccess := authorisePayment(penaltyPayment, p.PayableResourceDaoService, p.E5Client, e5PaymentID)
-	if !authorisePaymentSuccess {
-		return authorisePaymentError
+	var err error
+
+	err = withRetry(cfg, e5.CreateAction, func() error {
+		return createPayment(penaltyPayment, p.E5Client, e5PaymentID)
+	})
+
+	if err != nil {
+		// currently jsut saving the error as it is in the transient block and the retry topic has
+		// not yet been developed. Once developed this saveE5Error should be removed, and a new message
+		// should be put onto the retry topic
+		saveE5Error(penaltyPayment, p.PayableResourceDaoService, err, e5PaymentID, e5.CreateAction)
+		// put it on the retry topic
+		return err
 	}
 
-	confirmPaymentError, confirmPaymentSuccess := confirmPayment(penaltyPayment, p.PayableResourceDaoService, p.E5Client, e5PaymentID)
-	if !confirmPaymentSuccess {
-		return confirmPaymentError
+	err = withRetry(cfg, e5.AuthoriseAction, func() error {
+		return authorisePayment(penaltyPayment, p.E5Client, e5PaymentID)
+	})
+
+	if err != nil {
+		saveE5Error(penaltyPayment, p.PayableResourceDaoService, err, e5PaymentID, e5.AuthoriseAction)
+		return err
+	}
+
+	err = withRetry(cfg, e5.ConfirmAction, func() error {
+		return confirmPayment(penaltyPayment, p.E5Client, e5PaymentID)
+	})
+
+	if err != nil {
+		saveE5Error(penaltyPayment, p.PayableResourceDaoService, err, e5PaymentID, e5.ConfirmAction)
+		return err
 	}
 
 	log.Info("Financial penalty payment processing successful", logContext)
 	return nil
 }
 
-func createPayment(penaltyPayment models.PenaltyPaymentsProcessing, payableResourceDaoService dao.PayableResourceDaoService, client e5.ClientInterface, e5PaymentID string) (createPaymentError error, createPaymentSuccess bool) {
+// This method should be called by the retry topic - currently not being used
+func (p PenaltyFinancePayment) ProcessFinancialPenaltyPaymentRetryTopic(penaltyPayment models.PenaltyPaymentsProcessing, e5PaymentID string) error {
+	logContext := log.Data{
+		"customer_code":           penaltyPayment.CustomerCode,
+		"company_code":            penaltyPayment.CompanyCode,
+		"payable_ref":             penaltyPayment.PayableRef,
+		"penalty_payment_message": penaltyPayment,
+		"e5_payment_id":           e5PaymentID,
+	}
+	log.Info("Financial penalty payment processing started", logContext)
+
+	if isAfterNextDayMidnight(penaltyPayment.CreatedAt) {
+		err := errors.New("trying to process penalty payment on the day after it was paid")
+		// it should be ok to save it as a CreateAction failure as the create would have needed to fail initially to
+		// make it onto the retry queue
+		saveE5Error(penaltyPayment, p.PayableResourceDaoService, err, e5PaymentID, e5.CreateAction)
+		log.Info("Skipping financial penalty payment processing as current time is after next day midnight of created_at", logContext)
+		// this should now be marked as processed on the retry topic
+		return nil
+	}
+
+	var err error
+
+	err = createPayment(penaltyPayment, p.E5Client, e5PaymentID)
+	if err != nil {
+		// Should go back on the retry topic with the number of attempts updated
+		return err
+	}
+
+	err = authorisePayment(penaltyPayment, p.E5Client, e5PaymentID)
+	if err != nil {
+		saveE5Error(penaltyPayment, p.PayableResourceDaoService, err, e5PaymentID, e5.AuthoriseAction)
+		// this should now be marked as processed on the retry topic as the create succeeded - we are not tracking state
+		return nil
+	}
+
+	err = confirmPayment(penaltyPayment, p.E5Client, e5PaymentID)
+	if err != nil {
+		saveE5Error(penaltyPayment, p.PayableResourceDaoService, err, e5PaymentID, e5.ConfirmAction)
+		// this should now be marked as processed on the retry topic as the create succeeded - we are not tracking state
+		return nil
+	}
+
+	log.Info("Financial penalty payment processing successful", logContext)
+	// this should now be marked as processed on the retry topic
+	return nil
+}
+
+func isAfterNextDayMidnight(createdAt string) bool {
+	parsed, _ := time.Parse(time.RFC3339, createdAt)
+	nextDayMidnight := time.Date(parsed.Year(), parsed.Month(), parsed.Day()+1, 0, 0, 0, 0, parsed.Location())
+	return time.Now().After(nextDayMidnight)
+}
+
+func withRetry(cfg *config.Config, action e5.Action, fn func() error) error {
+	attempts := getMaxRetryAttempts(cfg)
+	delay := getDelay(cfg)
+	maxDelay := getMaxDelay(cfg)
+
+	return retry.Do(
+		fn,
+		retry.Attempts(attempts),
+		retry.Delay(delay),
+		retry.MaxDelay(maxDelay),
+		retry.OnRetry(func(n uint, err error) {
+			log.Info("Penalty payment processing retry attempt failed: " + string(action))
+		}),
+	)
+}
+
+func getMaxRetryAttempts(cfg *config.Config) uint {
+	var attemptsStr = cfg.PenaltyPaymentsProcessingMaxRetries
+	var attempts = uint(3)
+	if s, err := strconv.ParseUint(attemptsStr, 10, 32); err == nil {
+		attempts = uint(s)
+	}
+	return attempts
+}
+
+func getDelay(cfg *config.Config) time.Duration {
+	var delayStr = cfg.PenaltyPaymentsProcessingRetryDelay
+	var delay = 1 * time.Second
+	if d, err := strconv.ParseInt(delayStr, 10, 32); err == nil {
+		delay = time.Duration(d) * time.Second
+	}
+	return delay
+}
+
+func getMaxDelay(cfg *config.Config) time.Duration {
+	var maxDelayStr = cfg.PenaltyPaymentsProcessingRetryMaxDelay
+	var maxDelay = 5 * time.Second
+	if m, err := strconv.ParseUint(maxDelayStr, 10, 32); err == nil {
+		maxDelay = time.Duration(m) * time.Second
+	}
+	return maxDelay
+}
+
+func createPayment(penaltyPayment models.PenaltyPaymentsProcessing, client e5.ClientInterface,
+	e5PaymentID string) (err error) {
 	var e5Transactions []*e5.CreatePaymentTransaction
 
 	for _, t := range penaltyPayment.TransactionPayments {
@@ -61,48 +190,48 @@ func createPayment(penaltyPayment models.PenaltyPaymentsProcessing, payableResou
 			Value:                t.Value,
 		})
 	}
-	createPaymentError = client.CreatePayment(&e5.CreatePaymentInput{
+	err = client.CreatePayment(&e5.CreatePaymentInput{
 		CompanyCode:  penaltyPayment.CompanyCode,
 		CustomerCode: penaltyPayment.CustomerCode,
 		PaymentID:    e5PaymentID,
 		TotalValue:   penaltyPayment.TotalValue,
 		Transactions: e5Transactions,
 	})
-	if createPaymentError != nil {
-		saveE5Error(penaltyPayment, payableResourceDaoService, createPaymentError, e5PaymentID, e5.CreateAction)
-		return createPaymentError, false
+	if err != nil {
+		return err
 	}
-	return nil, true
+	return nil
 }
 
-func authorisePayment(penaltyPayment models.PenaltyPaymentsProcessing, payableResourceDaoService dao.PayableResourceDaoService, client e5.ClientInterface, e5PaymentID string) (authorisePaymentError error, authorisePaymentSuccess bool) {
-	authorisePaymentError = client.AuthorisePayment(&e5.AuthorisePaymentInput{
+func authorisePayment(penaltyPayment models.PenaltyPaymentsProcessing, client e5.ClientInterface,
+	e5PaymentID string) (err error) {
+	err = client.AuthorisePayment(&e5.AuthorisePaymentInput{
 		CompanyCode:   penaltyPayment.CompanyCode,
 		PaymentID:     e5PaymentID,
 		CardReference: penaltyPayment.ExternalPaymentID,
 		CardType:      penaltyPayment.CardType,
 		Email:         penaltyPayment.Email,
 	})
-	if authorisePaymentError != nil {
-		saveE5Error(penaltyPayment, payableResourceDaoService, authorisePaymentError, e5PaymentID, e5.AuthoriseAction)
-		return authorisePaymentError, false
+	if err != nil {
+		return err
 	}
-	return nil, true
+	return nil
 }
 
-func confirmPayment(penaltyPayment models.PenaltyPaymentsProcessing, payableResourceDaoService dao.PayableResourceDaoService, client e5.ClientInterface, e5PaymentID string) (confirmPaymentError error, confirmPaymentSuccess bool) {
-	confirmPaymentError = client.ConfirmPayment(&e5.PaymentActionInput{
+func confirmPayment(penaltyPayment models.PenaltyPaymentsProcessing, client e5.ClientInterface,
+	e5PaymentID string) (err error) {
+	err = client.ConfirmPayment(&e5.PaymentActionInput{
 		CompanyCode: penaltyPayment.CompanyCode,
 		PaymentID:   e5PaymentID,
 	})
-	if confirmPaymentError != nil {
-		saveE5Error(penaltyPayment, payableResourceDaoService, confirmPaymentError, e5PaymentID, e5.ConfirmAction)
-		return confirmPaymentError, false
+	if err != nil {
+		return err
 	}
-	return nil, true
+	return nil
 }
 
-func saveE5Error(penaltyPayment models.PenaltyPaymentsProcessing, payableResourceDaoService dao.PayableResourceDaoService, e5PaymentError error, e5PaymentID string, e5Action e5.Action) {
+func saveE5Error(penaltyPayment models.PenaltyPaymentsProcessing, payableResourceDaoService dao.PayableResourceDaoService,
+	e5PaymentError error, e5PaymentID string, e5Action e5.Action) {
 	logContext := log.Data{
 		"customer_code": penaltyPayment.CustomerCode,
 		"company_code":  penaltyPayment.CompanyCode,

--- a/handlers/payment_details.go
+++ b/handlers/payment_details.go
@@ -10,8 +10,6 @@ import (
 	"github.com/companieshouse/penalty-payment-api/config"
 )
 
-var getPenaltyRefTypeFromTransaction = utils.GetPenaltyRefTypeFromTransaction
-
 // HandleGetPaymentDetails retrieves costs for a supplied company number and reference.
 func HandleGetPaymentDetails(penaltyDetailsMap *config.PenaltyDetailsMap) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {

--- a/handlers/penalties.go
+++ b/handlers/penalties.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-var getCompanyCode = utils.GetCompanyCode
 var accountPenalties = api.AccountPenalties
 
 // HandleGetPenalties retrieves the penalty details for the supplied customer code from e5

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -17,7 +17,6 @@ import (
 )
 
 var payableResourceService *services.PayableResourceService
-var paymentDetailsService *service.PaymentDetailsService
 
 // Register defines the route mappings for the main router and it's subrouters
 func Register(mainRouter *mux.Router, cfg *config.Config, prDaoService dao.PayableResourceDaoService,

--- a/handlers/vars.go
+++ b/handlers/vars.go
@@ -1,0 +1,13 @@
+package handlers
+
+import (
+	"github.com/companieshouse/penalty-payment-api/common/utils"
+	"github.com/companieshouse/penalty-payment-api/penalty_payments/service"
+)
+
+var (
+	paymentDetailsService            *service.PaymentDetailsService
+	getCompanyCode                   = utils.GetCompanyCode
+	getCompanyCodeFromTransaction    = utils.GetCompanyCodeFromTransaction
+	getPenaltyRefTypeFromTransaction = utils.GetPenaltyRefTypeFromTransaction
+)

--- a/penalty_payments/service/payment_notification_service.go
+++ b/penalty_payments/service/payment_notification_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/companieshouse/chs.go/avro"
 	"github.com/companieshouse/chs.go/kafka/producer"
@@ -75,6 +76,7 @@ func preparePaymentProcessingKafkaMessage(penaltyPaymentProcessingSchema avro.Sc
 
 	log.Debug("penalty payment processing message", log.Data{
 		"attempt":             penaltyPaymentProcessing.Attempt,
+		"created_at":          penaltyPaymentProcessing.CreatedAt,
 		"company_code":        penaltyPaymentProcessing.CompanyCode,
 		"customer_code":       penaltyPaymentProcessing.CustomerCode,
 		"payment_id":          penaltyPaymentProcessing.PaymentID,
@@ -102,6 +104,7 @@ func constructMessage(payableResource models.PayableResource, companyCode string
 
 	penaltyPaymentProcessing := models.PenaltyPaymentsProcessing{
 		Attempt:           1,
+		CreatedAt:         time.Now().UTC().Format(time.RFC3339),
 		CompanyCode:       companyCode,
 		CustomerCode:      payableResource.CustomerCode,
 		PaymentID:         payment.PaymentID,


### PR DESCRIPTION
Add retry for transient E5 errors
Using the avast Go library to manage the retries.
Also included method for the retry topic that will not be called until the retry consumer is implemented

Related Config: https://github.com/companieshouse/docker-chs-development/pull/1867