### PR TITLE
SAN-542 Improve error log for "failed to send penalty payments processing message"

### DIFF
--- a/penalty_payments/service/email_service.go
+++ b/penalty_payments/service/email_service.go
@@ -70,7 +70,8 @@ func SendEmailKafkaMessage(payableResource models.PayableResource, req *http.Req
 
 	partition, offset, err := kafkaProducer.Send(message)
 	if err != nil {
-		err = fmt.Errorf("failed to send email send message in partition: %d at offset %d", partition, offset)
+		err = fmt.Errorf("failed to send email send message: [%v]", err)
+		log.Error(err, logContext)
 		return err
 	}
 	log.Info("successfully published email send message", logContext, log.Data{

--- a/penalty_payments/service/payment_notification_service.go
+++ b/penalty_payments/service/payment_notification_service.go
@@ -59,7 +59,8 @@ func PaymentProcessingKafkaMessage(payableResource models.PayableResource, payme
 
 	partition, offset, err := kafkaProducer.Send(message)
 	if err != nil {
-		err = fmt.Errorf("failed to send penalty payments processing message in partition: %d at offset %d", partition, offset)
+		err = fmt.Errorf("failed to send penalty payments processing message: [%v]", err)
+		log.Error(err, logContext)
 		return err
 	}
 	log.Info("successfully published penalty payments processing message", logContext, log.Data{


### PR DESCRIPTION
[SAN-542](https://companieshouse.atlassian.net/browse/SAN-542) Improve error log for "failed to send penalty payments processing message"
* "message":"failed to send penalty payments processing message: [kafka server: Messages are rejected since there are fewer in-sync replicas than required.]"


[SAN-542]: https://companieshouse.atlassian.net/browse/SAN-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ