### PR TITLE
SAN-594 Ensure we only populate the kafka 3 broker address via application arguments

### DIFF
--- a/ecs-image-build/docker_start.sh
+++ b/ecs-image-build/docker_start.sh
@@ -13,4 +13,10 @@ IFS=',' read -ra BROKERS <<< "${KAFKA_BROKER_ADDR}"
 # Ensure we only populate the broker address and topic via application arguments
 unset KAFKA_BROKER_ADDR
 
-exec ./penalty-payment-api "-bind-addr=:${PORT}" $(for broker in "${BROKERS[@]}"; do echo -n "-broker-addr=${broker} "; done)
+# Read kafka 3 brokers from environment and split on comma
+IFS=',' read -ra KAFKA3_BROKERS <<< "${KAFKA3_BROKER_ADDR}"
+
+# Ensure we only populate the kafka 3 broker address via application arguments
+unset KAFKA3_BROKER_ADDR
+
+exec ./penalty-payment-api "-bind-addr=:${PORT}" $(for broker in "${BROKERS[@]}"; do echo -n "-broker-addr=${broker} "; done) $(for broker in "${KAFKA3_BROKERS[@]}"; do echo -n "-kafka3-broker-addr=${broker} "; done)


### PR DESCRIPTION
[SAN-594](https://companieshouse.atlassian.net/browse/SAN-594) Ensure we only populate the kafka 3 broker address via application arguments

Related PR: https://github.com/companieshouse/ecs-service-configs-dev/pull/1667

[SAN-594]: https://companieshouse.atlassian.net/browse/SAN-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ