### PR TITLE
SAN-377 Remove penalty payment class in support for either penalty-lfp / penalty-sanctions

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -679,8 +679,8 @@
           "items": {
             "type": "string",
             "enum": [
-              "penalty",
-              "data-maintenance"
+              "penalty-lfp",
+              "penalty-sanctions"
             ]
           }
         },


### PR DESCRIPTION
[SAN-377](https://companieshouse.atlassian.net/browse/SAN-377) Remove penalty payment class in support for either penalty-lfp / penalty-sanctions

Related PR: https://github.com/companieshouse/payments.api.ch.gov.uk/pull/265

[SAN-377]: https://companieshouse.atlassian.net/browse/SAN-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ