### PR TITLE
SAN-567 API log cleanup following test comments from amcknight-ch

### DIFF
--- a/common/dao/mongo.go
+++ b/common/dao/mongo.go
@@ -153,10 +153,10 @@ func (m *MongoAccountPenaltiesService) CreateAccountPenalties(dao *models.Accoun
 
 // GetAccountPenalties gets the account penalties from the account_penalties database collection
 func (m *MongoAccountPenaltiesService) GetAccountPenalties(customerCode string, companyCode string) (*models.AccountPenaltiesDao, error) {
-	log.Info("retrieving document in account_penalties collection", log.Data{
+	logContext := log.Data{
 		"customer_code": customerCode,
 		"company_code":  companyCode,
-	})
+	}
 
 	var resource models.AccountPenaltiesDao
 
@@ -169,30 +169,21 @@ func (m *MongoAccountPenaltiesService) GetAccountPenalties(customerCode string, 
 	err := dbResource.Err()
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			log.Debug("no document found in account_penalties collection", log.Data{
-				"customer_code": customerCode,
-				"company_code":  companyCode,
-			})
+			log.Debug("no document found in account_penalties collection", logContext)
 			return nil, err
 		}
-		log.Error(err, log.Data{
-			"customer_code": customerCode,
-			"company_code":  companyCode,
-		})
+		log.Error(err, logContext)
 		return nil, err
 	}
 
 	err = dbResource.Decode(&resource)
 
 	if err != nil {
-		log.Error(err, log.Data{
-			"customer_code": customerCode,
-			"company_code":  companyCode,
-		})
+		log.Error(err, logContext)
 		return nil, err
 	}
 
-	log.Debug("accountPenalties", log.Data{"accountPenalties": resource})
+	log.Debug("GetAccountPenalties", logContext, log.Data{"account_penalties": resource})
 
 	return &resource, nil
 }

--- a/issuer_gateway/api/account_penalties.go
+++ b/issuer_gateway/api/account_penalties.go
@@ -31,7 +31,6 @@ func AccountPenalties(penaltyRefType, customerCode, companyCode string,
 		log.Error(fmt.Errorf("error getting config: %v", err))
 		return nil, services.Error, nil
 	}
-	log.Debug("Config", log.Data{"Config": cfg})
 
 	companyInfoLogData := log.Data{"customer_code": customerCode, "company_code": companyCode}
 

--- a/issuer_gateway/private/match_penalty.go
+++ b/issuer_gateway/private/match_penalty.go
@@ -28,7 +28,7 @@ func MatchPenalty(referenceTransactions []models.TransactionListItem,
 		"customer_code": customerCode,
 	}
 
-	log.Debug("checking if penalty is payable", log.Data{"transaction_info": transactionInfo})
+	log.Debug("checking if penalty is payable", transactionInfo)
 
 	matched, ok := referenceTransactionsMap[transactionToMatch.PenaltyRef]
 	if !ok {

--- a/penalty_payments/consumer/consumer.go
+++ b/penalty_payments/consumer/consumer.go
@@ -104,7 +104,7 @@ func handleMessage(avroSchema *avro.Schema, message *sarama.ConsumerMessage, fin
 		"e5_payment_id": e5PaymentID,
 		"is_retry":      isRetry,
 	}
-	log.Info("Consumer handle message - BEFORE Financial penalty payment processing", log.Data{
+	log.Debug("Consumer handle message - BEFORE Financial penalty payment processing", log.Data{
 		"Topic":     message.Topic,
 		"Partition": message.Partition,
 		"Offset":    message.Offset,


### PR DESCRIPTION
[SAN-567](https://companieshouse.atlassian.net/browse/SAN-567) API log cleanup following test comments from amcknight-ch

Updated Debug logging 
* filter event = "debug" and data.message = "Config"
* filter event = "debug" and data.message = "adding payments processing message to topic"
* filter event = "debug" and data.message = "checking if penalty is payable"
* filter event = "debug" and data.message = "Consumer handle message - BEFORE Financial penalty payment processing"
* filter event = "debug" and data.message = "GetAccountPenalties"

Updated Info logging to improve the message
* filter event = "info" and data.message = "Send email kafka message sent"
* filter event = "info" and data.message = "Payment processing kafka message sent"

[SAN-567]: https://companieshouse.atlassian.net/browse/SAN-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ