### PR TITLE
SAN-669 Update GenerateTransactionListFromAccountPenalties param to be penaltyRefType

### DIFF
--- a/common/utils/reference.go
+++ b/common/utils/reference.go
@@ -57,11 +57,11 @@ func GetCustomerCodeFromVars(vars map[string]string) (string, error) {
 // GetCompanyCode gets the company code from the penalty reference type
 func GetCompanyCode(penaltyRefType string) (string, error) {
 	switch penaltyRefType {
-	case LateFilingPenRef:
+	case LateFilingPenaltyRefType:
 		return LateFilingPenaltyCompanyCode, nil
-	case SanctionsPenRef:
+	case SanctionsPenaltyRefType:
 		return SanctionsCompanyCode, nil
-	case SanctionsRoePenRef:
+	case SanctionsRoePenaltyRefType:
 		return SanctionsCompanyCode, nil
 	default:
 		return "", fmt.Errorf("invalid penalty reference type supplied")
@@ -98,11 +98,11 @@ func GetPenaltyRefTypeFromTransaction(transactions []models.TransactionItem) (st
 
 	switch penaltyPrefix {
 	case "A":
-		return LateFilingPenRef, nil
+		return LateFilingPenaltyRefType, nil
 	case "P":
-		return SanctionsPenRef, nil
+		return SanctionsPenaltyRefType, nil
 	case "U":
-		return SanctionsRoePenRef, nil
+		return SanctionsRoePenaltyRefType, nil
 	default:
 		return "", fmt.Errorf("error converting penalty reference")
 	}
@@ -125,7 +125,7 @@ func getPrefix(transactions []models.TransactionItem) (string, error) {
 const (
 	LateFilingPenaltyCompanyCode = "LP"
 	SanctionsCompanyCode         = "C1"
-	LateFilingPenRef             = "LATE_FILING"
-	SanctionsPenRef              = "SANCTIONS"
-	SanctionsRoePenRef           = "SANCTIONS_ROE"
+	LateFilingPenaltyRefType     = "LATE_FILING"
+	SanctionsPenaltyRefType      = "SANCTIONS"
+	SanctionsRoePenaltyRefType   = "SANCTIONS_ROE"
 )

--- a/common/utils/reference_test.go
+++ b/common/utils/reference_test.go
@@ -98,18 +98,18 @@ func TestUnitGetCompanyCode(t *testing.T) {
 		}{
 			{
 				name:          "Late Filing",
-				input:         LateFilingPenRef,
+				input:         LateFilingPenaltyRefType,
 				expectedCode:  LateFilingPenaltyCompanyCode,
 				expectedError: false,
 			},
 			{
 				name:         "Sanctions",
-				input:        SanctionsPenRef,
+				input:        SanctionsPenaltyRefType,
 				expectedCode: SanctionsCompanyCode,
 			},
 			{
 				name:         "Sanctions ROE",
-				input:        SanctionsRoePenRef,
+				input:        SanctionsRoePenaltyRefType,
 				expectedCode: SanctionsCompanyCode,
 			},
 			{
@@ -239,7 +239,7 @@ func TestUnitGetPenaltyRefTypeFromTransaction(t *testing.T) {
 						PenaltyRef: "A1000007",
 					},
 				},
-				expectedPenaltyRefType: LateFilingPenRef,
+				expectedPenaltyRefType: LateFilingPenaltyRefType,
 			},
 			{
 				name: "Sanctions",
@@ -250,7 +250,7 @@ func TestUnitGetPenaltyRefTypeFromTransaction(t *testing.T) {
 						PenaltyRef: "P1000007",
 					},
 				},
-				expectedPenaltyRefType: SanctionsPenRef,
+				expectedPenaltyRefType: SanctionsPenaltyRefType,
 			},
 			{
 				name: "Sanctions ROE",
@@ -261,7 +261,7 @@ func TestUnitGetPenaltyRefTypeFromTransaction(t *testing.T) {
 						PenaltyRef: "U1000007",
 					},
 				},
-				expectedPenaltyRefType: SanctionsRoePenRef,
+				expectedPenaltyRefType: SanctionsRoePenaltyRefType,
 			},
 			{
 				name: "Error unknown penalty reference",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -229,7 +229,7 @@ details:
 			Convey("Then the penalty details should be returned", func() {
 				So(err, ShouldBeNil)
 				So(penaltyDetailsMap.Name, ShouldEqual, "penalty details")
-				So(penaltyDetailsMap.Details[utils.LateFilingPenRef].EmailReceivedAppId, ShouldEqual, "penalty-payment-api.penalty_payment_received_email")
+				So(penaltyDetailsMap.Details[utils.LateFilingPenaltyRefType].EmailReceivedAppId, ShouldEqual, "penalty-payment-api.penalty_payment_received_email")
 			})
 		})
 	})

--- a/handlers/payment_details_test.go
+++ b/handlers/payment_details_test.go
@@ -71,7 +71,7 @@ func generateTestPayableResource(withTransaction bool, penaltyRef string) models
 
 func TestUnitHandleGetPaymentDetails(t *testing.T) {
 	Convey("No payable resource in request context", t, func() {
-		setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenRef)
+		setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenaltyRefType)
 
 		res := serveGetPaymentDetailsHandler(nil)
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
@@ -90,7 +90,7 @@ func TestUnitHandleGetPaymentDetails(t *testing.T) {
 	})
 
 	Convey("Payment PenaltyDetails not found due to no costs", t, func() {
-		setGetPenaltyRefTypeFromTransactionMock(utils.SanctionsPenRef)
+		setGetPenaltyRefTypeFromTransactionMock(utils.SanctionsPenaltyRefType)
 
 		payable := generateTestPayableResource(false, "")
 
@@ -108,19 +108,19 @@ func TestUnitHandleGetPaymentDetails(t *testing.T) {
 			{
 				name:           "Late Filing",
 				companyCode:    utils.LateFilingPenaltyCompanyCode,
-				penaltyRefType: utils.LateFilingPenRef,
+				penaltyRefType: utils.LateFilingPenaltyRefType,
 				penaltyRef:     "A1234567",
 			},
 			{
 				name:           "Sanctions",
 				companyCode:    utils.SanctionsCompanyCode,
-				penaltyRefType: utils.SanctionsPenRef,
+				penaltyRefType: utils.SanctionsPenaltyRefType,
 				penaltyRef:     "P1234567",
 			},
 			{
 				name:           "Sanctions ROE",
 				companyCode:    utils.SanctionsCompanyCode,
-				penaltyRefType: utils.SanctionsRoePenRef,
+				penaltyRefType: utils.SanctionsRoePenaltyRefType,
 				penaltyRef:     "U1234567",
 			},
 		}

--- a/handlers/penalties.go
+++ b/handlers/penalties.go
@@ -84,7 +84,7 @@ func HandleGetPenalties(apDaoSvc dao.AccountPenaltiesDaoService, penaltyDetailsM
 // so defaulting to LateFiling until agreement is made to update other services calling the api
 func GetPenaltyRefType(penaltyRefType string) string {
 	if len(penaltyRefType) == 0 {
-		return utils.LateFilingPenRef
+		return utils.LateFilingPenaltyRefType
 	} else {
 		return penaltyRefType
 	}

--- a/handlers/penalties_test.go
+++ b/handlers/penalties_test.go
@@ -94,22 +94,22 @@ func TestUnitHandleGetPenaltyRefType(t *testing.T) {
 			{
 				name:                   "Empty",
 				input:                  "",
-				expectedPenaltyRefType: utils.LateFilingPenRef,
+				expectedPenaltyRefType: utils.LateFilingPenaltyRefType,
 			},
 			{
 				name:                   "Late Filing",
-				input:                  utils.LateFilingPenRef,
-				expectedPenaltyRefType: utils.LateFilingPenRef,
+				input:                  utils.LateFilingPenaltyRefType,
+				expectedPenaltyRefType: utils.LateFilingPenaltyRefType,
 			},
 			{
 				name:                   "Sanctions",
-				input:                  utils.SanctionsPenRef,
-				expectedPenaltyRefType: utils.SanctionsPenRef,
+				input:                  utils.SanctionsPenaltyRefType,
+				expectedPenaltyRefType: utils.SanctionsPenaltyRefType,
 			},
 			{
 				name:                   "Sanctions ROE",
-				input:                  utils.SanctionsRoePenRef,
-				expectedPenaltyRefType: utils.SanctionsRoePenRef,
+				input:                  utils.SanctionsRoePenaltyRefType,
+				expectedPenaltyRefType: utils.SanctionsRoePenaltyRefType,
 			},
 		}
 

--- a/issuer_gateway/api/account_penalties_test.go
+++ b/issuer_gateway/api/account_penalties_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var penaltyRefType = utils.LateFilingPenRef
+var penaltyRefType = utils.LateFilingPenaltyRefType
 var customerCode = "12345678"
 var companyCode = "LP"
 var penaltyDetailsMap = &config.PenaltyDetailsMap{

--- a/issuer_gateway/api/payable_penalty_test.go
+++ b/issuer_gateway/api/payable_penalty_test.go
@@ -57,7 +57,7 @@ func accountPenaltiesResponse(unpaidPenaltyCount int) *models.TransactionListRes
 
 func generateParams(daoService dao.AccountPenaltiesDaoService, transaction models.TransactionItem) types.PayablePenaltyParams {
 	return types.PayablePenaltyParams{
-		PenaltyRefType:    utils.LateFilingPenRef,
+		PenaltyRefType:    utils.LateFilingPenaltyRefType,
 		CompanyCode:       utils.LateFilingPenaltyCompanyCode,
 		CustomerCode:      "10000024",
 		PenaltyDetailsMap: &config.PenaltyDetailsMap{},

--- a/issuer_gateway/private/generate_transaction_list.go
+++ b/issuer_gateway/private/generate_transaction_list.go
@@ -14,7 +14,7 @@ import (
 
 var etagGenerator = utils.GenerateEtag
 
-func GenerateTransactionListFromAccountPenalties(accountPenalties *models.AccountPenaltiesDao, companyCode string, penaltyDetailsMap *config.PenaltyDetailsMap,
+func GenerateTransactionListFromAccountPenalties(accountPenalties *models.AccountPenaltiesDao, penaltyRefType string, penaltyDetailsMap *config.PenaltyDetailsMap,
 	allowedTransactionsMap *models.AllowedTransactionMap, cfg *config.Config, requestId string) (*models.TransactionListResponse, error) {
 	payableTransactionList := models.TransactionListResponse{}
 	etag, err := etagGenerator()
@@ -31,7 +31,7 @@ func GenerateTransactionListFromAccountPenalties(accountPenalties *models.Accoun
 	for _, accountPenalty := range accountPenalties.AccountPenalties {
 		transactionType := getTransactionType(&accountPenalty, allowedTransactionsMap)
 		payableStatus := getPayableStatus(transactionType, &accountPenalty, accountPenalties.ClosedAt, accountPenalties.AccountPenalties, allowedTransactionsMap, cfg)
-		transactionListItem, err := buildTransactionListItemFromAccountPenalty(&accountPenalty, penaltyDetailsMap, companyCode, transactionType, payableStatus, requestId)
+		transactionListItem, err := buildTransactionListItemFromAccountPenalty(&accountPenalty, penaltyDetailsMap, penaltyRefType, transactionType, payableStatus, requestId)
 		if err != nil {
 			return nil, err
 		}
@@ -43,7 +43,7 @@ func GenerateTransactionListFromAccountPenalties(accountPenalties *models.Accoun
 }
 
 func buildTransactionListItemFromAccountPenalty(dao *models.AccountPenaltiesDataDao,
-	penaltyDetailsMap *config.PenaltyDetailsMap, companyCode string, transactionType string, payableStatus string, requestId string) (models.TransactionListItem, error) {
+	penaltyDetailsMap *config.PenaltyDetailsMap, penaltyRefType string, transactionType string, payableStatus string, requestId string) (models.TransactionListItem, error) {
 	etag, err := etagGenerator()
 	if err != nil {
 		err = fmt.Errorf("error generating etag: [%v]", err)
@@ -55,7 +55,7 @@ func buildTransactionListItemFromAccountPenalty(dao *models.AccountPenaltiesData
 	transactionListItem.Etag = etag
 	transactionListItem.ID = dao.TransactionReference
 	transactionListItem.IsPaid = dao.IsPaid
-	transactionListItem.Kind = penaltyDetailsMap.Details[companyCode].ResourceKind
+	transactionListItem.Kind = penaltyDetailsMap.Details[penaltyRefType].ResourceKind
 	transactionListItem.IsDCA = checkDunningStatus(dao, DCADunningStatus)
 	transactionListItem.DueDate = dao.DueDate
 	transactionListItem.MadeUpDate = dao.MadeUpDate

--- a/issuer_gateway/private/generate_transaction_list_test.go
+++ b/issuer_gateway/private/generate_transaction_list_test.go
@@ -47,9 +47,10 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return "", errors.New("error generating etag")
 		}
+		penaltyRefType := utils.LateFilingPenRef
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			lfpAccountPenaltiesDao, utils.LateFilingPenaltyCompanyCode, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			lfpAccountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err.Error(), ShouldStartWith, "error generating etag")
 		So(transactionList, ShouldBeNil)
@@ -64,9 +65,10 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 			}
 			return etag, nil
 		}
+		penaltyRefType := utils.LateFilingPenRef
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			lfpAccountPenaltiesDao, utils.LateFilingPenaltyCompanyCode, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			lfpAccountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err.Error(), ShouldStartWith, "error generating etag")
 		So(transactionList, ShouldBeNil)
@@ -76,12 +78,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.LateFilingPenRef
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-			customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, pen1DunningStatus, utils.LateFilingPenRef, true)
+			customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, pen1DunningStatus, penaltyRefType, true)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			accountPenaltiesDao, utils.LateFilingPenaltyCompanyCode, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			accountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -110,9 +112,10 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
+		penaltyRefType := utils.LateFilingPenRef
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			lfpAccountPenaltiesDao, utils.LateFilingPenaltyCompanyCode, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			lfpAccountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -141,12 +144,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.LateFilingPenRef
 		otherAccountPenalties := buildTestUnpaidAccountPenaltiesDao(
-			customerCode, utils.LateFilingPenaltyCompanyCode, otherTransactionSubType, pen1DunningStatus, utils.LateFilingPenRef, false)
+			customerCode, utils.LateFilingPenaltyCompanyCode, otherTransactionSubType, pen1DunningStatus, penaltyRefType, false)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			otherAccountPenalties, utils.LateFilingPenaltyCompanyCode, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			otherAccountPenalties, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -176,12 +179,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.LateFilingPenRef
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-			customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, dcaDunningStatus, utils.LateFilingPenRef, false)
+			customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, dcaDunningStatus, penaltyRefType, false)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			accountPenaltiesDao, utils.LateFilingPenaltyCompanyCode, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			accountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
 		transactionListItems := transactionList.Items
@@ -209,12 +212,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.SanctionsPenRef
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-			customerCode, utils.SanctionsCompanyCode, SanctionsTransactionSubType, pen1DunningStatus, utils.SanctionsPenRef, false)
+			customerCode, utils.SanctionsCompanyCode, SanctionsTransactionSubType, pen1DunningStatus, penaltyRefType, false)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			accountPenaltiesDao, utils.SanctionsCompanyCode, sanctionsPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			accountPenaltiesDao, penaltyRefType, sanctionsPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -243,12 +246,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.SanctionsRoePenRef
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-			overSeasEntityId, utils.SanctionsCompanyCode, SanctionsRoeFailureToUpdateTransactionSubType, pen1DunningStatus, utils.SanctionsRoePenRef, false)
+			overSeasEntityId, utils.SanctionsCompanyCode, SanctionsRoeFailureToUpdateTransactionSubType, pen1DunningStatus, penaltyRefType, false)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			accountPenaltiesDao, utils.SanctionsCompanyCode, sanctionsRoePenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			accountPenaltiesDao, penaltyRefType, sanctionsRoePenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -277,12 +280,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.SanctionsPenRef
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-			customerCode, utils.SanctionsCompanyCode, SanctionsTransactionSubType, dcaDunningStatus, utils.SanctionsPenRef, false)
+			customerCode, utils.SanctionsCompanyCode, SanctionsTransactionSubType, dcaDunningStatus, penaltyRefType, false)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			accountPenaltiesDao, utils.SanctionsCompanyCode, sanctionsPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			accountPenaltiesDao, penaltyRefType, sanctionsPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -311,12 +314,12 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-
+		penaltyRefType := utils.SanctionsRoePenRef
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-			overSeasEntityId, utils.SanctionsCompanyCode, SanctionsRoeFailureToUpdateTransactionSubType, dcaDunningStatus, utils.SanctionsRoePenRef, false)
+			overSeasEntityId, utils.SanctionsCompanyCode, SanctionsRoeFailureToUpdateTransactionSubType, dcaDunningStatus, penaltyRefType, false)
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
-			accountPenaltiesDao, utils.SanctionsCompanyCode, sanctionsRoePenaltyDetailsMap, allowedTransactionMap, &cfg, "")
+			accountPenaltiesDao, penaltyRefType, sanctionsRoePenaltyDetailsMap, allowedTransactionMap, &cfg, "")
 
 		So(err, ShouldBeNil)
 		So(transactionList, ShouldNotBeNil)
@@ -1257,7 +1260,7 @@ func buildTestAccountPenaltiesDataDao(params AccountPenaltiesParams) models.Acco
 	}
 }
 
-func buildTestUnpaidAccountPenaltiesDao(customerCode, companyCode, transactionSubType, dunningStatus, penaltyType string, withUnpaidCost bool) *models.AccountPenaltiesDao {
+func buildTestUnpaidAccountPenaltiesDao(customerCode, companyCode, transactionSubType, dunningStatus, penaltyRefType string, withUnpaidCost bool) *models.AccountPenaltiesDao {
 	params := AccountPenaltiesParams{
 		CompanyCode:        companyCode,
 		CustomerCode:       customerCode,
@@ -1268,7 +1271,7 @@ func buildTestUnpaidAccountPenaltiesDao(customerCode, companyCode, transactionSu
 		AccountStatus:      CHSAccountStatus,
 		DunningStatus:      dunningStatus,
 	}
-	switch penaltyType {
+	switch penaltyRefType {
 	case utils.SanctionsPenRef:
 		{
 			params.TransactionReference = "P1234567"
@@ -1307,14 +1310,14 @@ func buildTestUnpaidAccountPenaltiesDao(customerCode, companyCode, transactionSu
 	}
 }
 
-func buildTestPenaltyDetailsMap(penaltyType string) *config.PenaltyDetailsMap {
+func buildTestPenaltyDetailsMap(penaltyRefType string) *config.PenaltyDetailsMap {
 	penaltyDetailsMap := config.PenaltyDetailsMap{
 		Name:    "penalty details",
 		Details: map[string]config.PenaltyDetails{},
 	}
-	switch penaltyType {
+	switch penaltyRefType {
 	case utils.LateFilingPenRef:
-		penaltyDetailsMap.Details[utils.LateFilingPenaltyCompanyCode] = config.PenaltyDetails{
+		penaltyDetailsMap.Details[penaltyRefType] = config.PenaltyDetails{
 			Description:        "Late Filing Penalty",
 			DescriptionId:      "late-filing-penalty",
 			ClassOfPayment:     "penalty-lfp",
@@ -1324,7 +1327,7 @@ func buildTestPenaltyDetailsMap(penaltyType string) *config.PenaltyDetailsMap {
 			EmailMsgType:       "penalty_payment_received_email",
 		}
 	case utils.SanctionsPenRef:
-		penaltyDetailsMap.Details[utils.SanctionsCompanyCode] = config.PenaltyDetails{
+		penaltyDetailsMap.Details[penaltyRefType] = config.PenaltyDetails{
 			Description:        "Sanctions Penalty Payment",
 			DescriptionId:      "penalty-sanctions",
 			ClassOfPayment:     "penalty-sanctions",
@@ -1333,8 +1336,8 @@ func buildTestPenaltyDetailsMap(penaltyType string) *config.PenaltyDetailsMap {
 			EmailReceivedAppId: "penalty-payment-api.penalty_payment_received_email",
 			EmailMsgType:       "penalty_payment_received_email",
 		}
-	default:
-		penaltyDetailsMap.Details[utils.SanctionsCompanyCode] = config.PenaltyDetails{
+	case utils.SanctionsRoePenRef:
+		penaltyDetailsMap.Details[penaltyRefType] = config.PenaltyDetails{
 			Description:        "Overseas Entity Penalty Payment",
 			DescriptionId:      "penalty-sanctions",
 			ClassOfPayment:     "penalty-sanctions",

--- a/issuer_gateway/private/generate_transaction_list_test.go
+++ b/issuer_gateway/private/generate_transaction_list_test.go
@@ -38,16 +38,16 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 	pen1DunningStatus := addTrailingSpacesToDunningStatus(PEN1DunningStatus)
 	dcaDunningStatus := addTrailingSpacesToDunningStatus(DCADunningStatus)
 	lfpAccountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
-		customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, pen1DunningStatus, utils.LateFilingPenRef, false)
-	lfpPenaltyDetailsMap := buildTestPenaltyDetailsMap(utils.LateFilingPenRef)
-	sanctionsPenaltyDetailsMap := buildTestPenaltyDetailsMap(utils.SanctionsPenRef)
-	sanctionsRoePenaltyDetailsMap := buildTestPenaltyDetailsMap(utils.SanctionsRoePenRef)
+		customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, pen1DunningStatus, utils.LateFilingPenaltyRefType, false)
+	lfpPenaltyDetailsMap := buildTestPenaltyDetailsMap(utils.LateFilingPenaltyRefType)
+	sanctionsPenaltyDetailsMap := buildTestPenaltyDetailsMap(utils.SanctionsPenaltyRefType)
+	sanctionsRoePenaltyDetailsMap := buildTestPenaltyDetailsMap(utils.SanctionsRoePenaltyRefType)
 
 	Convey("error when first etag generator fails", t, func() {
 		etagGenerator = func() (string, error) {
 			return "", errors.New("error generating etag")
 		}
-		penaltyRefType := utils.LateFilingPenRef
+		penaltyRefType := utils.LateFilingPenaltyRefType
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
 			lfpAccountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
@@ -65,7 +65,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 			}
 			return etag, nil
 		}
-		penaltyRefType := utils.LateFilingPenRef
+		penaltyRefType := utils.LateFilingPenaltyRefType
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
 			lfpAccountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
@@ -78,7 +78,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.LateFilingPenRef
+		penaltyRefType := utils.LateFilingPenaltyRefType
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
 			customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, pen1DunningStatus, penaltyRefType, true)
 
@@ -112,7 +112,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.LateFilingPenRef
+		penaltyRefType := utils.LateFilingPenaltyRefType
 
 		transactionList, err := GenerateTransactionListFromAccountPenalties(
 			lfpAccountPenaltiesDao, penaltyRefType, lfpPenaltyDetailsMap, allowedTransactionMap, &cfg, "")
@@ -144,7 +144,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.LateFilingPenRef
+		penaltyRefType := utils.LateFilingPenaltyRefType
 		otherAccountPenalties := buildTestUnpaidAccountPenaltiesDao(
 			customerCode, utils.LateFilingPenaltyCompanyCode, otherTransactionSubType, pen1DunningStatus, penaltyRefType, false)
 
@@ -179,7 +179,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.LateFilingPenRef
+		penaltyRefType := utils.LateFilingPenaltyRefType
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
 			customerCode, utils.LateFilingPenaltyCompanyCode, euTransactionSubType, dcaDunningStatus, penaltyRefType, false)
 
@@ -212,7 +212,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.SanctionsPenRef
+		penaltyRefType := utils.SanctionsPenaltyRefType
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
 			customerCode, utils.SanctionsCompanyCode, SanctionsTransactionSubType, pen1DunningStatus, penaltyRefType, false)
 
@@ -246,7 +246,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.SanctionsRoePenRef
+		penaltyRefType := utils.SanctionsRoePenaltyRefType
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
 			overSeasEntityId, utils.SanctionsCompanyCode, SanctionsRoeFailureToUpdateTransactionSubType, pen1DunningStatus, penaltyRefType, false)
 
@@ -280,7 +280,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.SanctionsPenRef
+		penaltyRefType := utils.SanctionsPenaltyRefType
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
 			customerCode, utils.SanctionsCompanyCode, SanctionsTransactionSubType, dcaDunningStatus, penaltyRefType, false)
 
@@ -314,7 +314,7 @@ func TestUnitGenerateTransactionListFromE5Response(t *testing.T) {
 		etagGenerator = func() (string, error) {
 			return etag, nil
 		}
-		penaltyRefType := utils.SanctionsRoePenRef
+		penaltyRefType := utils.SanctionsRoePenaltyRefType
 		accountPenaltiesDao := buildTestUnpaidAccountPenaltiesDao(
 			overSeasEntityId, utils.SanctionsCompanyCode, SanctionsRoeFailureToUpdateTransactionSubType, dcaDunningStatus, penaltyRefType, false)
 
@@ -1272,14 +1272,14 @@ func buildTestUnpaidAccountPenaltiesDao(customerCode, companyCode, transactionSu
 		DunningStatus:      dunningStatus,
 	}
 	switch penaltyRefType {
-	case utils.SanctionsPenRef:
+	case utils.SanctionsPenaltyRefType:
 		{
 			params.TransactionReference = "P1234567"
 			params.TransactionType = SanctionsTransactionType
 			params.LedgerCode = "E1"
 			params.TypeDescription = "CS01                                    "
 		}
-	case utils.LateFilingPenRef:
+	case utils.LateFilingPenaltyRefType:
 		{
 			params.TransactionReference = "A1234567"
 			params.TransactionType = "1"
@@ -1316,7 +1316,7 @@ func buildTestPenaltyDetailsMap(penaltyRefType string) *config.PenaltyDetailsMap
 		Details: map[string]config.PenaltyDetails{},
 	}
 	switch penaltyRefType {
-	case utils.LateFilingPenRef:
+	case utils.LateFilingPenaltyRefType:
 		penaltyDetailsMap.Details[penaltyRefType] = config.PenaltyDetails{
 			Description:        "Late Filing Penalty",
 			DescriptionId:      "late-filing-penalty",
@@ -1326,7 +1326,7 @@ func buildTestPenaltyDetailsMap(penaltyRefType string) *config.PenaltyDetailsMap
 			EmailReceivedAppId: "penalty-payment-api.penalty_payment_received_email",
 			EmailMsgType:       "penalty_payment_received_email",
 		}
-	case utils.SanctionsPenRef:
+	case utils.SanctionsPenaltyRefType:
 		penaltyDetailsMap.Details[penaltyRefType] = config.PenaltyDetails{
 			Description:        "Sanctions Penalty Payment",
 			DescriptionId:      "penalty-sanctions",
@@ -1336,7 +1336,7 @@ func buildTestPenaltyDetailsMap(penaltyRefType string) *config.PenaltyDetailsMap
 			EmailReceivedAppId: "penalty-payment-api.penalty_payment_received_email",
 			EmailMsgType:       "penalty_payment_received_email",
 		}
-	case utils.SanctionsRoePenRef:
+	case utils.SanctionsRoePenaltyRefType:
 		penaltyDetailsMap.Details[penaltyRefType] = config.PenaltyDetails{
 			Description:        "Overseas Entity Penalty Payment",
 			DescriptionId:      "penalty-sanctions",

--- a/penalty_payments/service/email_service_test.go
+++ b/penalty_payments/service/email_service_test.go
@@ -120,17 +120,17 @@ func TestUnitPrepareEmailKafkaMessage(t *testing.T) {
 			{
 				name:           "Late Filing",
 				companyCode:    utils.LateFilingPenaltyCompanyCode,
-				penaltyRefType: utils.LateFilingPenRef,
+				penaltyRefType: utils.LateFilingPenaltyRefType,
 			},
 			{
 				name:           "Sanctions",
 				companyCode:    utils.SanctionsCompanyCode,
-				penaltyRefType: utils.SanctionsPenRef,
+				penaltyRefType: utils.SanctionsPenaltyRefType,
 			},
 			{
 				name:           "Sanctions ROE",
 				companyCode:    utils.SanctionsCompanyCode,
-				penaltyRefType: utils.SanctionsRoePenRef,
+				penaltyRefType: utils.SanctionsRoePenaltyRefType,
 			},
 		}
 
@@ -227,7 +227,7 @@ func TestUnitPrepareEmailKafkaMessage(t *testing.T) {
 
 			getConfig = mockedConfigGet
 			getCompanyName = mockedGetCompanyName
-			setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenRef)
+			setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenaltyRefType)
 
 			mockApDaoSvc := mocks.NewMockAccountPenaltiesDaoService(ctrl)
 
@@ -253,7 +253,7 @@ func TestUnitPrepareEmailKafkaMessage(t *testing.T) {
 
 			getConfig = mockedConfigGet
 			getCompanyName = mockedGetCompanyName
-			setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenRef)
+			setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenaltyRefType)
 
 			mockApDaoSvc := mocks.NewMockAccountPenaltiesDaoService(ctrl)
 

--- a/penalty_payments/service/payment_details_test.go
+++ b/penalty_payments/service/payment_details_test.go
@@ -19,7 +19,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	penaltyDetails := penaltyDetailsMap.Details[utils.LateFilingPenaltyCompanyCode]
+	penaltyDetails := penaltyDetailsMap.Details[utils.LateFilingPenRef]
 
 	Convey("Get payment details no transactions - invalid data", t, func() {
 

--- a/penalty_payments/service/payment_details_test.go
+++ b/penalty_payments/service/payment_details_test.go
@@ -19,7 +19,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	penaltyDetails := penaltyDetailsMap.Details[utils.LateFilingPenRef]
+	penaltyDetails := penaltyDetailsMap.Details[utils.LateFilingPenaltyRefType]
 
 	Convey("Get payment details no transactions - invalid data", t, func() {
 
@@ -77,7 +77,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 				resourceKind:          "late-filing-penalty#late-filing-penalty",
 				productType:           "late-filing-penalty",
 				companyCode:           utils.LateFilingPenaltyCompanyCode,
-				penaltyRefType:        utils.LateFilingPenRef,
+				penaltyRefType:        utils.LateFilingPenaltyRefType,
 			},
 			{
 				description:           "Sanctions Penalty Payment",
@@ -87,7 +87,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 				resourceKind:          "penalty#sanctions",
 				productType:           "penalty-sanctions",
 				companyCode:           utils.SanctionsCompanyCode,
-				penaltyRefType:        utils.SanctionsPenRef,
+				penaltyRefType:        utils.SanctionsPenaltyRefType,
 			},
 			{
 				description:           "Overseas Entity Penalty Payment",
@@ -97,7 +97,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 				resourceKind:          "penalty#sanctions",
 				productType:           "penalty-sanctions",
 				companyCode:           utils.SanctionsCompanyCode,
-				penaltyRefType:        utils.SanctionsRoePenRef,
+				penaltyRefType:        utils.SanctionsRoePenaltyRefType,
 			},
 		}
 		for _, tc := range testCases {
@@ -184,7 +184,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 				resourceKind:          "late-filing-penalty#late-filing-penalty",
 				productType:           "late-filing-penalty",
 				companyCode:           utils.LateFilingPenaltyCompanyCode,
-				penaltyRefType:        utils.LateFilingPenRef,
+				penaltyRefType:        utils.LateFilingPenaltyRefType,
 			},
 			{
 				description:           "Sanctions Penalty Payment",
@@ -194,7 +194,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 				resourceKind:          "penalty#sanctions",
 				productType:           "penalty-sanctions",
 				companyCode:           utils.SanctionsCompanyCode,
-				penaltyRefType:        utils.SanctionsPenRef,
+				penaltyRefType:        utils.SanctionsPenaltyRefType,
 			},
 			{
 				description:           "Overseas Entity Penalty Payment",
@@ -204,7 +204,7 @@ func TestUnitGetPaymentDetailsFromPayableResource(t *testing.T) {
 				resourceKind:          "penalty#sanctions",
 				productType:           "penalty-sanctions",
 				companyCode:           utils.SanctionsCompanyCode,
-				penaltyRefType:        utils.SanctionsRoePenRef,
+				penaltyRefType:        utils.SanctionsRoePenaltyRefType,
 			},
 		}
 		for _, tc := range testCases {

--- a/penalty_payments/service/payment_notification_service_test.go
+++ b/penalty_payments/service/payment_notification_service_test.go
@@ -159,7 +159,7 @@ func TestUnitPreparePaymentProcessingKafkaMessage(t *testing.T) {
 			})
 		})
 		Convey("When config is called with no transaction items", func() {
-			setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenRef)
+			setGetPenaltyRefTypeFromTransactionMock(utils.LateFilingPenaltyRefType)
 
 			Convey("Then an error should be returned", func() {
 				payableResourceNoItems := models.PayableResource{

--- a/penalty_payments/transformers/payable_resource_test.go
+++ b/penalty_payments/transformers/payable_resource_test.go
@@ -163,7 +163,7 @@ func TestUnitPayableResourceToPaymentDetails(t *testing.T) {
 				resourceKind:          "late-filing-penalty#late-filing-penalty",
 				productType:           "late-filing-penalty",
 				companyCode:           utils.LateFilingPenaltyCompanyCode,
-				penaltyRefType:        utils.LateFilingPenRef,
+				penaltyRefType:        utils.LateFilingPenaltyRefType,
 			},
 			{
 				description:           "Sanctions Penalty Payment",
@@ -173,7 +173,7 @@ func TestUnitPayableResourceToPaymentDetails(t *testing.T) {
 				resourceKind:          "penalty#sanctions",
 				productType:           "penalty-sanctions",
 				companyCode:           utils.SanctionsCompanyCode,
-				penaltyRefType:        utils.SanctionsPenRef,
+				penaltyRefType:        utils.SanctionsPenaltyRefType,
 			},
 			{
 				description:           "Overseas Entity Penalty Payment",
@@ -183,7 +183,7 @@ func TestUnitPayableResourceToPaymentDetails(t *testing.T) {
 				resourceKind:          "penalty#sanctions",
 				productType:           "penalty-sanctions",
 				companyCode:           utils.SanctionsCompanyCode,
-				penaltyRefType:        utils.SanctionsRoePenRef,
+				penaltyRefType:        utils.SanctionsRoePenaltyRefType,
 			},
 		}
 		for _, tc := range testCases {


### PR DESCRIPTION
[SAN-669](https://companieshouse.atlassian.net/browse/SAN-669) Update GenerateTransactionListFromAccountPenalties param to be penaltyRefType

* Update constants for penaltyRefType: LateFilingPenaltyRefType / SanctionsPenaltyRefType / SanctionsRoePenaltyRefType

[SAN-669]: https://companieshouse.atlassian.net/browse/SAN-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ