### PR TITLE
SAN-785: Use the new financial penalty config to determine the status…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/companieshouse/go-sdk-manager v0.1.12
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
-	github.com/companieshouse/penalty-payment-api-core v1.20.0
+	github.com/companieshouse/penalty-payment-api-core v1.20.1
 	github.com/docker/go-connections v0.5.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/companieshouse/gofigure v0.1.4/go.mod h1:lBAsI13q21rMce+pO7x4xUYAXzO0
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
 github.com/companieshouse/penalty-payment-api-core v1.20.0 h1:/BQ8UnsmbYpiz99FIR7ZYlyMWQk4pj3kenvRM3yKL8k=
 github.com/companieshouse/penalty-payment-api-core v1.20.0/go.mod h1:gLPA1tq+DDgJXK4CSgCXcaQIVkR+PZWEAIvTxCNPOq8=
+github.com/companieshouse/penalty-payment-api-core v1.20.1/go.mod h1:gLPA1tq+DDgJXK4CSgCXcaQIVkR+PZWEAIvTxCNPOq8=
 github.com/companieshouse/private-api-sdk-go v0.1.11/go.mod h1:EaRgxVpcHv6IZ1LKp2xqE4rdEsQwgYqVz3g/BIHQVD4=
 github.com/companieshouse/private-api-sdk-go v0.1.13 h1:o9PD1aSVu3+tbf/WUZT/wX1e0DNx+9xcJugbqo7rbxE=
 github.com/companieshouse/private-api-sdk-go v0.1.13/go.mod h1:g1zvBCn8Tyc45x+5BmlHsq+BYwuekd5FLRaFOqTUu+A=

--- a/issuer_gateway/private/generate_transaction_list.go
+++ b/issuer_gateway/private/generate_transaction_list.go
@@ -35,12 +35,15 @@ func GenerateTransactionListFromAccountPenalties(accountPenalties *models.Accoun
 	payableTransactionList.Etag = etag
 	payableTransactionList.TotalResults = len(accountPenalties.AccountPenalties)
 
+	financePaymentConfig := penaltyConfig.PayablePenalties[penaltyRefType].FinancePayment
+
 	// Loop through penalties and construct CH resources
 	for _, accountPenalty := range accountPenalties.AccountPenalties {
 		transactionType := getTransactionType(&accountPenalty, penaltyConfig.PenaltyTypes)
 		reason := transactionListItemEnrichmentProviders.ReasonProvider.GetReason(&accountPenalty, penaltyConfig.PenaltyTypes)
 		payableStatus := transactionListItemEnrichmentProviders.PayableStatusProvider.GetPayableStatus(
-			transactionType, &accountPenalty, accountPenalties.ClosedAt, accountPenalties.AccountPenalties, penaltyConfig.PenaltyTypes, cfg)
+			transactionType, &accountPenalty, accountPenalties.ClosedAt,
+			accountPenalties.AccountPenalties, penaltyConfig.PenaltyTypes, cfg, *financePaymentConfig)
 		transactionListItem, err := buildTransactionListItemFromAccountPenalty(
 			&accountPenalty, penaltyConfig.PayablePenalties, penaltyRefType, transactionType, reason, payableStatus, requestId)
 		if err != nil {

--- a/issuer_gateway/private/payable_status_provider.go
+++ b/issuer_gateway/private/payable_status_provider.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/penalty-payment-api-core/finance_config"
 	"github.com/companieshouse/penalty-payment-api-core/models"
 	"github.com/companieshouse/penalty-payment-api/common/utils"
@@ -23,17 +24,35 @@ const (
 type PayableStatusProvider interface {
 	GetPayableStatus(transactionType string, e5Transaction *models.AccountPenaltiesDataDao, closedAt *time.Time,
 		e5Transactions []models.AccountPenaltiesDataDao, penaltyTypes map[string]map[string]finance_config.FinancePenaltyTypeConfig,
-		cfg *config.Config) string
+		cfg *config.Config, financePaymentConfig finance_config.FinancePaymentConfig) string
 }
 
 type DefaultPayableStatusProvider struct{}
 
-func (provider *DefaultPayableStatusProvider) GetPayableStatus(transactionType string, e5Transaction *models.AccountPenaltiesDataDao, closedAt *time.Time,
-	e5Transactions []models.AccountPenaltiesDataDao, penaltyTypes map[string]map[string]finance_config.FinancePenaltyTypeConfig, cfg *config.Config) string {
+func (provider *DefaultPayableStatusProvider) GetPayableStatus(transactionType string, e5Transaction *models.AccountPenaltiesDataDao,
+	closedAt *time.Time, e5Transactions []models.AccountPenaltiesDataDao, penaltyTypes map[string]map[string]finance_config.FinancePenaltyTypeConfig,
+	cfg *config.Config, financePaymentConfig finance_config.FinancePaymentConfig) string {
 	if types.Penalty.String() == transactionType {
-		if penaltyTransactionSubTypeDisabled(e5Transaction, cfg) {
+		txType := e5Transaction.TransactionType
+		txSubtype := e5Transaction.TransactionSubType
+
+		if penaltyConfigTransactionSubTypeDisabled(txSubtype, cfg) {
 			return DisabledPayableStatus
 		}
+
+		found, disabled := penaltyTypeTransactionSubTypeStatus(penaltyTypes, txType, txSubtype)
+		if found {
+			if disabled {
+				return DisabledPayableStatus
+			}
+		} else {
+			return ClosedPayableStatus
+		}
+
+		if payablePenaltySubTypeAbsent(financePaymentConfig, txType, txSubtype) {
+			return ClosedPayableStatus
+		}
+
 		closedPayableStatus, isClosed := checkClosedPayableStatus(e5Transaction, closedAt, e5Transactions, penaltyTypes)
 		if isClosed {
 			return closedPayableStatus
@@ -141,14 +160,63 @@ func penaltyPaymentAllocated(penalty *models.AccountPenaltiesDataDao) bool {
 	return penalty.OutstandingAmount == 0
 }
 
-func penaltyTransactionSubTypeDisabled(penalty *models.AccountPenaltiesDataDao, cfg *config.Config) bool {
+// penaltyConfigTransactionSubTypeDisabled checks the config override that is set via the DISABLED_PENALTY_TRANSACTION_SUBTYPES
+// environment variable that can be used to disable a subtype
+func penaltyConfigTransactionSubTypeDisabled(txSubtype string, cfg *config.Config) bool {
+	log.Debug("Disabled subtypes: ", log.Data{
+		"DISABLED_PENALTY_TRANSACTION_SUBTYPES": cfg.DisabledPenaltyTransactionSubtypes})
 	trimDisabledSubtypes := strings.ReplaceAll(cfg.DisabledPenaltyTransactionSubtypes, " ", "")
 	disabledSubtypes := strings.Split(trimDisabledSubtypes, ",")
-	penaltySubType := penalty.TransactionSubType
+	penaltySubType := txSubtype
 	for _, subType := range disabledSubtypes {
 		if penaltySubType == subType {
 			return true
 		}
 	}
+
 	return false
+}
+
+// penaltyTypeTransactionSubTypeStatus returns a boolean to indicate if the subtype has been found in the financial
+// penalty type config, and a boolean to return the status of the disabled config value if set
+func penaltyTypeTransactionSubTypeStatus(penaltyTypes map[string]map[string]finance_config.FinancePenaltyTypeConfig, txType, txSubType string) (bool, bool) {
+	subtypesMap, ok := penaltyTypes[txType]
+	if !ok || subtypesMap == nil {
+		log.Info("Penalty Type Config transaction type not found: ", log.Data{
+			"transaction_type": txType})
+		return false, false
+	}
+
+	subtypeCfg, ok := subtypesMap[txSubType]
+	if !ok {
+		log.Info("Penalty Type Config transaction subtype not found: ", log.Data{
+			"transaction_subtype": txSubType})
+		return false, false
+	}
+
+	log.Info("Penalty Type Config transaction subtype not found: ", log.Data{
+		"transaction_subtype": txSubType,
+		"disabled":            subtypeCfg.Disabled})
+
+	return true, subtypeCfg.Disabled
+}
+
+// payablePenaltySubTypeAbsent returns a boolean to indicate if the subtype exists in the finance payment configuration
+func payablePenaltySubTypeAbsent(financePaymentConfig finance_config.FinancePaymentConfig, txType, txSubType string) bool {
+	if financePaymentConfig.TransactionType != txType {
+		log.Info("Finance Payment Config transaction subtype not found: ", log.Data{
+			"transaction_subtype": txType})
+		return true
+	}
+
+	for _, v := range financePaymentConfig.TransactionSubTypes {
+		if v == txSubType {
+			return false
+		}
+	}
+
+	log.Info("Finance Payment Config transaction subtype not found: ", log.Data{
+		"transaction_subtype": txSubType})
+
+	return true
 }

--- a/issuer_gateway/private/payable_status_provider_test.go
+++ b/issuer_gateway/private/payable_status_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/companieshouse/penalty-payment-api-core/finance_config"
 	"github.com/companieshouse/penalty-payment-api-core/models"
 	"github.com/companieshouse/penalty-payment-api/common/utils"
 	"github.com/companieshouse/penalty-payment-api/issuer_gateway/types"
@@ -14,6 +15,9 @@ import (
 func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 
 	penaltyConfig := testutils.LoadPenaltyConfigContext()
+	lateFilingPayableConfig := penaltyConfig.PayablePenalties["LATE_FILING"].FinancePayment
+	sanctionsPayableConfig := penaltyConfig.PayablePenalties["SANCTIONS"].FinancePayment
+	sanctionsROEPayableConfig := penaltyConfig.PayablePenalties["SANCTIONS_ROE"].FinancePayment
 
 	Convey("Get open payable status for late filing penalty", t, func() {
 		type args struct {
@@ -127,7 +131,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				closedAt := &yesterday
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *lateFilingPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -208,7 +213,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				closedAt := &yesterday
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *lateFilingPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -283,7 +289,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			Convey(tc.name, func() {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -365,7 +372,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				closedAt := &yesterday
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -440,7 +448,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			Convey(tc.name, func() {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -522,7 +531,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				closedAt := &yesterday
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -597,7 +607,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			Convey(tc.name, func() {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsROEPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -697,7 +708,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				closedAt := &yesterday
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsROEPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -709,21 +721,25 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			penalty *models.AccountPenaltiesDataDao
 		}
 		testCases := []struct {
-			name string
-			args args
+			name       string
+			paymentCfg finance_config.FinancePaymentConfig
+			args       args
 		}{
 			{
-				name: "Late filing penalty paid today",
+				name:       "Late filing penalty paid today",
+				paymentCfg: *lateFilingPayableConfig,
 				args: args{penalty: buildLateFilingPenaltyTestAccountPenaltiesDataDao(true, 150, CHSAccountStatus,
 					addTrailingSpacesToDunningStatus(PEN1DunningStatus))},
 			},
 			{
-				name: "Sanctions penalty paid today",
+				name:       "Sanctions penalty paid today",
+				paymentCfg: *sanctionsPayableConfig,
 				args: args{penalty: buildSanctionsConfirmationStatementTestAccountPenaltiesDataDao(true, 250, CHSAccountStatus,
 					addTrailingSpacesToDunningStatus(PEN1DunningStatus))},
 			},
 			{
-				name: "Sanctions ROE penalty paid today",
+				name:       "Sanctions ROE penalty paid today",
+				paymentCfg: *sanctionsROEPayableConfig,
 				args: args{penalty: buildSanctionsRoeTestAccountPenaltiesDataDao(true, 250, CHSAccountStatus,
 					addTrailingSpacesToDunningStatus(PEN1DunningStatus))},
 			},
@@ -733,7 +749,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				closedAt := &now
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, closedAt,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, tc.paymentCfg)
 
 				So(got, ShouldEqual, ClosedPendingAllocationPayableStatus)
 			})
@@ -757,7 +774,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 
 		// When
 		provider := &DefaultPayableStatusProvider{}
-		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil, e5Transactions, penaltyConfig.PenaltyTypes, &cfg)
+		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil,
+			e5Transactions, penaltyConfig.PenaltyTypes, &cfg, *lateFilingPayableConfig)
 
 		// Then
 		So(got, ShouldEqual, ClosedInstalmentPlanPayableStatus)
@@ -780,7 +798,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 
 		// When
 		provider := &DefaultPayableStatusProvider{}
-		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil, e5Transactions, penaltyConfig.PenaltyTypes, &cfg)
+		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil,
+			e5Transactions, penaltyConfig.PenaltyTypes, &cfg, *lateFilingPayableConfig)
 
 		// Then
 		So(got, ShouldEqual, ClosedPayableStatus)
@@ -795,7 +814,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 
 		// When
 		provider := &DefaultPayableStatusProvider{}
-		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil, e5Transactions, penaltyConfig.PenaltyTypes, &cfg)
+		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil,
+			e5Transactions, penaltyConfig.PenaltyTypes, &cfg, *lateFilingPayableConfig)
 
 		// Then
 		So(got, ShouldEqual, ClosedPenStrategyExhaustedPayableStatus)
@@ -810,7 +830,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 
 		// When
 		provider := &DefaultPayableStatusProvider{}
-		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil, e5Transactions, penaltyConfig.PenaltyTypes, &cfg)
+		got := provider.GetPayableStatus(types.Penalty.String(), &lateFilingPaidPenalty, nil,
+			e5Transactions, penaltyConfig.PenaltyTypes, &cfg, *lateFilingPayableConfig)
 
 		// Then
 		So(got, ShouldEqual, ClosedPayableStatus)
@@ -825,8 +846,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 		closedAt := time.Now()
 		e5Transactions := []models.AccountPenaltiesDataDao{*oldPaidPenalty, *newPaidPenalty}
 		provider := &DefaultPayableStatusProvider{}
-		So(provider.GetPayableStatus(types.Penalty.String(), oldPaidPenalty, &closedAt, e5Transactions, penaltyConfig.PenaltyTypes, &cfg), ShouldEqual, ClosedPayableStatus)
-		So(provider.GetPayableStatus(types.Penalty.String(), newPaidPenalty, &closedAt, e5Transactions, penaltyConfig.PenaltyTypes, &cfg), ShouldEqual, ClosedPendingAllocationPayableStatus)
+		So(provider.GetPayableStatus(types.Penalty.String(), oldPaidPenalty, &closedAt, e5Transactions, penaltyConfig.PenaltyTypes, &cfg, *sanctionsROEPayableConfig), ShouldEqual, ClosedPayableStatus)
+		So(provider.GetPayableStatus(types.Penalty.String(), newPaidPenalty, &closedAt, e5Transactions, penaltyConfig.PenaltyTypes, &cfg, *sanctionsROEPayableConfig), ShouldEqual, ClosedPendingAllocationPayableStatus)
 
 	})
 
@@ -899,7 +920,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			Convey(tc.name, func() {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -975,7 +997,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			Convey(tc.name, func() {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -1051,7 +1074,8 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			Convey(tc.name, func() {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
-				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now, []models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, *sanctionsROEPayableConfig)
 
 				So(got, ShouldEqual, tc.want)
 			})
@@ -1063,18 +1087,21 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 			penalty *models.AccountPenaltiesDataDao
 		}
 		testCases := []struct {
-			name string
-			args args
-			want string
+			name       string
+			paymentCfg finance_config.FinancePaymentConfig
+			args       args
+			want       string
 		}{
 			{
-				name: "Sanctions (valid)",
+				name:       "Sanctions (valid)",
+				paymentCfg: *sanctionsPayableConfig,
 				args: args{penalty: buildSanctionsConfirmationStatementTestAccountPenaltiesDataDao(false, 250, CHSAccountStatus,
 					addTrailingSpacesToDunningStatus(PEN1DunningStatus))},
 				want: DisabledPayableStatus,
 			},
 			{
-				name: "Sanctions ROE (valid)",
+				name:       "Sanctions ROE (valid)",
+				paymentCfg: *sanctionsPayableConfig,
 				args: args{penalty: buildSanctionsRoeTestAccountPenaltiesDataDao(false, 250, CHSAccountStatus,
 					addTrailingSpacesToDunningStatus(PEN1DunningStatus))},
 				want: DisabledPayableStatus,
@@ -1086,7 +1113,7 @@ func TestUnitDefaultPayableStatusProvider_GetPayableStatus(t *testing.T) {
 				penalty := tc.args.penalty
 				provider := &DefaultPayableStatusProvider{}
 				got := provider.GetPayableStatus(types.Penalty.String(), penalty, &now,
-					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg)
+					[]models.AccountPenaltiesDataDao{*penalty}, penaltyConfig.PenaltyTypes, &cfg, tc.paymentCfg)
 
 				So(got, ShouldEqual, tc.want)
 			})


### PR DESCRIPTION
Use the new financial penalty config to determine the status of a penalty
Remove the once loading check of the test helper method for file load